### PR TITLE
feat: 共通テストユーティリティの実装 (#28)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,7 +11,15 @@ func main() {
 	e := echo.New()
 
 	// Middleware
-	e.Use(middleware.Logger())
+	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
+		LogStatus: true,
+		LogURI:    true,
+		LogMethod: true,
+		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
+			e.Logger.Infof("%s %s %d", v.Method, v.URI, v.Status)
+			return nil
+		},
+	}))
 	e.Use(middleware.Recover())
 	e.Use(middleware.CORS())
 

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,19 @@ module hackz-ptera/back
 
 go 1.24.2
 
-require github.com/labstack/echo/v4 v4.14.0
+require (
+	github.com/google/uuid v1.6.0
+	github.com/kyiku/hackz-ptera-back v0.0.0-20251218102843-e1892b806f9c
+	github.com/labstack/echo/v4 v4.14.0
+	github.com/stretchr/testify v1.11.1
+)
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
@@ -15,4 +22,5 @@ require (
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.24.2
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/kyiku/hackz-ptera-back v0.0.0-20251218102843-e1892b806f9c
 	github.com/labstack/echo/v4 v4.14.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/kyiku/hackz-ptera-back v0.0.0-20251218102843-e1892b806f9c h1:YYOTic8AD+gPHSGFnpXVqumpJ6rS465tosC4jt4jzjA=
-github.com/kyiku/hackz-ptera-back v0.0.0-20251218102843-e1892b806f9c/go.mod h1:Uk4D0nWTnBizdfy7TLzRuU9nOTsqtzf06hTnmUT1IdE=
 github.com/labstack/echo/v4 v4.14.0 h1:+tiMrDLxwv6u0oKtD03mv+V1vXXB3wCqPHJqPuIe+7M=
 github.com/labstack/echo/v4 v4.14.0/go.mod h1:xmw1clThob0BSVRX1CRQkGQ/vjwcpOMjQZSZa9fKA/c=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/kyiku/hackz-ptera-back v0.0.0-20251218102843-e1892b806f9c h1:YYOTic8AD+gPHSGFnpXVqumpJ6rS465tosC4jt4jzjA=
+github.com/kyiku/hackz-ptera-back v0.0.0-20251218102843-e1892b806f9c/go.mod h1:Uk4D0nWTnBizdfy7TLzRuU9nOTsqtzf06hTnmUT1IdE=
 github.com/labstack/echo/v4 v4.14.0 h1:+tiMrDLxwv6u0oKtD03mv+V1vXXB3wCqPHJqPuIe+7M=
 github.com/labstack/echo/v4 v4.14.0/go.mod h1:xmw1clThob0BSVRX1CRQkGQ/vjwcpOMjQZSZa9fKA/c=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=
@@ -27,5 +31,7 @@ golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
 golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
 golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
 golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/ai/bedrock.go
+++ b/internal/ai/bedrock.go
@@ -1,0 +1,123 @@
+// Package ai provides AI integration for password analysis.
+package ai
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// BedrockClientInterface defines the interface for Bedrock client.
+type BedrockClientInterface interface {
+	InvokeModel(modelID string, prompt string) (string, error)
+}
+
+// BedrockClient wraps the Bedrock client for password analysis.
+type BedrockClient struct {
+	client          BedrockClientInterface
+	region          string
+	fallbackEnabled bool
+}
+
+// ClaudeResponse represents the response from Claude.
+type ClaudeResponse struct {
+	Content []ContentBlock `json:"content"`
+}
+
+// ContentBlock represents a content block in Claude's response.
+type ContentBlock struct {
+	Text string `json:"text"`
+}
+
+// Claude 3 Haiku model ID
+const claudeHaikuModelID = "anthropic.claude-3-haiku-20240307-v1:0"
+
+// NewBedrockClient creates a new BedrockClient.
+func NewBedrockClient(client BedrockClientInterface, region string) *BedrockClient {
+	return &BedrockClient{
+		client:          client,
+		region:          region,
+		fallbackEnabled: false,
+	}
+}
+
+// EnableFallback enables or disables fallback mode.
+// When enabled, returns a fallback message instead of error when API fails.
+func (c *BedrockClient) EnableFallback(enabled bool) {
+	c.fallbackEnabled = enabled
+}
+
+// AnalyzePassword sends the password to Claude for analysis.
+func (c *BedrockClient) AnalyzePassword(password string) (string, error) {
+	prompt := c.buildPrompt(password)
+
+	response, err := c.client.InvokeModel(claudeHaikuModelID, prompt)
+	if err != nil {
+		if c.fallbackEnabled {
+			return c.getFallbackMessage(password), nil
+		}
+		return "", fmt.Errorf("failed to invoke Bedrock: %w", err)
+	}
+
+	result, err := c.parseResponse(response)
+	if err != nil {
+		if c.fallbackEnabled {
+			return c.getFallbackMessage(password), nil
+		}
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return result, nil
+}
+
+// buildPrompt creates the prompt for password analysis.
+func (c *BedrockClient) buildPrompt(password string) string {
+	return fmt.Sprintf(`あなたはパスワードを分析する皮肉っぽいAIアシスタントです。
+ユーザーが入力したパスワードを見て、そのパスワードから推測できることを指摘してください。
+名前や生年月日、ペットの名前など、個人情報が含まれていそうな場合は指摘してください。
+弱いパスワードの場合は「弱いパスワード」という言葉を使って批評してください。
+強そうなパスワードでも何か意味がありそうなら推測してください。
+
+パスワード: %s
+
+短く（1-2文で）日本語で回答してください。`, password)
+}
+
+// parseResponse parses the Claude response JSON.
+func (c *BedrockClient) parseResponse(response string) (string, error) {
+	var claudeResp ClaudeResponse
+	if err := json.Unmarshal([]byte(response), &claudeResp); err != nil {
+		return "", err
+	}
+
+	if len(claudeResp.Content) == 0 {
+		return "", errors.New("empty content in response")
+	}
+
+	return claudeResp.Content[0].Text, nil
+}
+
+// getFallbackMessage returns a fallback message when API fails.
+func (c *BedrockClient) getFallbackMessage(password string) string {
+	// Simple fallback analysis
+	if len(password) < 8 {
+		return "短すぎるパスワードです。もう少し長くしてください。"
+	}
+
+	hasDigit := false
+	hasLetter := false
+	for _, r := range password {
+		if r >= '0' && r <= '9' {
+			hasDigit = true
+		}
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			hasLetter = true
+		}
+	}
+
+	if !hasDigit || !hasLetter {
+		return "数字と文字を組み合わせてください。"
+	}
+
+	return "まあまあのパスワードですね。"
+}

--- a/internal/ai/bedrock_test.go
+++ b/internal/ai/bedrock_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/ai/bedrock_test.go
+++ b/internal/ai/bedrock_test.go
@@ -97,7 +97,7 @@ func TestBedrockClient_Prompt(t *testing.T) {
 			mockBedrock.Response = `{"content":[{"text":"分析結果"}]}`
 
 			client := NewBedrockClient(mockBedrock, "ap-northeast-1")
-			client.AnalyzePassword(tt.password)
+			_, _ = client.AnalyzePassword(tt.password)
 
 			for _, want := range tt.wantInPrompt {
 				assert.Contains(t, mockBedrock.LastPrompt, want)
@@ -111,7 +111,7 @@ func TestBedrockClient_ModelID(t *testing.T) {
 	mockBedrock.Response = `{"content":[{"text":"結果"}]}`
 
 	client := NewBedrockClient(mockBedrock, "ap-northeast-1")
-	client.AnalyzePassword("test")
+	_, _ = client.AnalyzePassword("test")
 
 	// Claude 3 Haikuモデルが使用されていることを確認
 	assert.Contains(t, mockBedrock.LastModelID, "claude-3-haiku")

--- a/internal/captcha/generator.go
+++ b/internal/captcha/generator.go
@@ -1,0 +1,151 @@
+// Package captcha provides CAPTCHA generation for image-based verification.
+package captcha
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/draw"
+	"image/png"
+	"math/rand"
+
+	"github.com/google/uuid"
+)
+
+// S3ClientInterface defines the interface for S3 operations.
+type S3ClientInterface interface {
+	GetObject(key string) ([]byte, error)
+	PutObject(key string, data []byte) error
+	ListObjects(prefix string) ([]string, error)
+}
+
+// Generator generates CAPTCHA images.
+type Generator struct {
+	s3Client      S3ClientInterface
+	cloudfrontURL string
+}
+
+// NewGenerator creates a new CAPTCHA generator.
+func NewGenerator(s3Client S3ClientInterface, cloudfrontURL string) *Generator {
+	return &Generator{
+		s3Client:      s3Client,
+		cloudfrontURL: cloudfrontURL,
+	}
+}
+
+// Generate creates a new CAPTCHA image with a hidden character.
+// Returns the composed image, character X position, character Y position, and error.
+func (g *Generator) Generate() (image.Image, int, int, error) {
+	// Get random background image
+	bgImg, err := g.getRandomBackgroundImage()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("failed to get background: %w", err)
+	}
+
+	// Get character image
+	charImg, err := g.getCharacterImage()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("failed to get character: %w", err)
+	}
+
+	// Calculate random position for character
+	bgBounds := bgImg.Bounds()
+	charBounds := charImg.Bounds()
+
+	maxX := bgBounds.Dx() - charBounds.Dx()
+	maxY := bgBounds.Dy() - charBounds.Dy()
+
+	if maxX <= 0 {
+		maxX = 1
+	}
+	if maxY <= 0 {
+		maxY = 1
+	}
+
+	targetX := rand.Intn(maxX)
+	targetY := rand.Intn(maxY)
+
+	// Compose the image
+	result := g.Compose(bgImg, charImg, targetX, targetY)
+
+	return result, targetX, targetY, nil
+}
+
+// getRandomBackgroundImage retrieves a random background image from S3.
+func (g *Generator) getRandomBackgroundImage() (image.Image, error) {
+	keys, err := g.s3Client.ListObjects("backgrounds/")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list backgrounds: %w", err)
+	}
+
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("no background images found")
+	}
+
+	// Select random background
+	key := keys[rand.Intn(len(keys))]
+
+	data, err := g.s3Client.GetObject(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get background image: %w", err)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode background image: %w", err)
+	}
+
+	return img, nil
+}
+
+// getCharacterImage retrieves the character image from S3.
+func (g *Generator) getCharacterImage() (image.Image, error) {
+	data, err := g.s3Client.GetObject("character/char.png")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get character image: %w", err)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode character image: %w", err)
+	}
+
+	return img, nil
+}
+
+// Compose overlays the character image onto the background at the specified position.
+func (g *Generator) Compose(bg image.Image, char image.Image, x, y int) image.Image {
+	bgBounds := bg.Bounds()
+	result := image.NewRGBA(bgBounds)
+
+	// Draw background
+	draw.Draw(result, bgBounds, bg, bgBounds.Min, draw.Src)
+
+	// Draw character at specified position
+	charBounds := char.Bounds()
+	destRect := image.Rect(x, y, x+charBounds.Dx(), y+charBounds.Dy())
+	draw.Draw(result, destRect, char, charBounds.Min, draw.Over)
+
+	return result
+}
+
+// Upload uploads the CAPTCHA image to S3 and returns the CloudFront URL.
+func (g *Generator) Upload(img image.Image) (string, error) {
+	// Generate unique filename
+	filename := uuid.New().String() + ".png"
+	key := "captcha/" + filename
+
+	// Encode image to PNG
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return "", fmt.Errorf("failed to encode image: %w", err)
+	}
+
+	// Upload to S3
+	if err := g.s3Client.PutObject(key, buf.Bytes()); err != nil {
+		return "", fmt.Errorf("failed to upload image: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/%s", g.cloudfrontURL, key)
+	return url, nil
+}

--- a/internal/captcha/generator_test.go
+++ b/internal/captcha/generator_test.go
@@ -4,7 +4,7 @@ import (
 	"image"
 	"testing"
 
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/delay/delay.go
+++ b/internal/delay/delay.go
@@ -1,0 +1,92 @@
+// Package delay provides random delay generation and execution.
+package delay
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// DelayGenerator generates random delays within a specified range.
+type DelayGenerator struct {
+	minSec int
+	maxSec int
+}
+
+// NewDelayGenerator creates a new DelayGenerator with the specified range.
+func NewDelayGenerator(minSec, maxSec int) *DelayGenerator {
+	return &DelayGenerator{
+		minSec: minSec,
+		maxSec: maxSec,
+	}
+}
+
+// NewDefaultDelayGenerator creates a DelayGenerator with default settings (10-30 seconds).
+func NewDefaultDelayGenerator() *DelayGenerator {
+	return NewDelayGenerator(10, 30)
+}
+
+// Generate generates a random delay duration within the configured range.
+func (g *DelayGenerator) Generate() time.Duration {
+	if g.minSec == g.maxSec {
+		return time.Duration(g.minSec) * time.Second
+	}
+	rangeSize := g.maxSec - g.minSec + 1
+	randomSec := g.minSec + rand.Intn(rangeSize)
+	return time.Duration(randomSec) * time.Second
+}
+
+// DelayExecutor executes delays with optional callbacks.
+type DelayExecutor struct {
+	mu       sync.Mutex
+	canceled bool
+	timer    *time.Timer
+}
+
+// NewDelayExecutor creates a new DelayExecutor.
+func NewDelayExecutor() *DelayExecutor {
+	return &DelayExecutor{}
+}
+
+// Execute waits for the specified duration.
+func (e *DelayExecutor) Execute(delay time.Duration) {
+	e.mu.Lock()
+	e.canceled = false
+	e.mu.Unlock()
+
+	if delay <= 0 {
+		return
+	}
+
+	time.Sleep(delay)
+}
+
+// ExecuteWithCallback waits for the specified duration and then calls the callback.
+// The callback is not called if Cancel is called before the delay completes.
+func (e *DelayExecutor) ExecuteWithCallback(delay time.Duration, callback func()) {
+	e.mu.Lock()
+	e.canceled = false
+	e.timer = time.NewTimer(delay)
+	e.mu.Unlock()
+
+	<-e.timer.C
+
+	e.mu.Lock()
+	wasCanceled := e.canceled
+	e.mu.Unlock()
+
+	if !wasCanceled && callback != nil {
+		callback()
+	}
+}
+
+// Cancel cancels any pending delay execution.
+func (e *DelayExecutor) Cancel() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.canceled = true
+	if e.timer != nil {
+		e.timer.Stop()
+	}
+}

--- a/internal/failure/handler.go
+++ b/internal/failure/handler.go
@@ -27,7 +27,7 @@ func NewFailureHandler(queue QueueInterface) *FailureHandler {
 func (h *FailureHandler) HandleFailure(user *model.User, message string) error {
 	// Send failure message via WebSocket
 	if user.Conn != nil {
-		user.Conn.WriteJSON(map[string]interface{}{
+		_ = user.Conn.WriteJSON(map[string]interface{}{
 			"type":           "failure",
 			"message":        message,
 			"redirect_delay": float64(3),
@@ -44,7 +44,7 @@ func (h *FailureHandler) HandleFailure(user *model.User, message string) error {
 
 	// Close connection after sending message
 	if user.Conn != nil {
-		user.Conn.Close()
+		_ = user.Conn.Close()
 	}
 
 	return nil

--- a/internal/failure/handler.go
+++ b/internal/failure/handler.go
@@ -1,0 +1,71 @@
+// Package failure provides failure handling for the application.
+package failure
+
+import (
+	"hackz-ptera/back/internal/model"
+)
+
+// QueueInterface defines the interface for the waiting queue.
+type QueueInterface interface {
+	Add(userID string, conn model.WebSocketConn)
+}
+
+// FailureHandler handles user failures and resets their state.
+type FailureHandler struct {
+	queue QueueInterface
+}
+
+// NewFailureHandler creates a new FailureHandler.
+func NewFailureHandler(queue QueueInterface) *FailureHandler {
+	return &FailureHandler{
+		queue: queue,
+	}
+}
+
+// HandleFailure processes a user failure, sends notification, closes connection,
+// and adds the user back to the waiting queue.
+func (h *FailureHandler) HandleFailure(user *model.User, message string) error {
+	// Send failure message via WebSocket
+	if user.Conn != nil {
+		user.Conn.WriteJSON(map[string]interface{}{
+			"type":           "failure",
+			"message":        message,
+			"redirect_delay": float64(3),
+		})
+	}
+
+	// Reset user state
+	user.ResetToWaiting()
+
+	// Add back to queue
+	if h.queue != nil {
+		h.queue.Add(user.ID, user.Conn)
+	}
+
+	// Close connection after sending message
+	if user.Conn != nil {
+		user.Conn.Close()
+	}
+
+	return nil
+}
+
+// HandleCaptchaFailure handles CAPTCHA verification failure.
+func (h *FailureHandler) HandleCaptchaFailure(user *model.User) error {
+	return h.HandleFailure(user, "3回失敗しました。待機列の最後尾からやり直しです。")
+}
+
+// HandleDinoFailure handles Dino Run game failure.
+func (h *FailureHandler) HandleDinoFailure(user *model.User) error {
+	return h.HandleFailure(user, "ゲームオーバー。待機列の最後尾からやり直しです。")
+}
+
+// HandleOTPFailure handles OTP verification failure.
+func (h *FailureHandler) HandleOTPFailure(user *model.User) error {
+	return h.HandleFailure(user, "魚の名前を3回間違えました。")
+}
+
+// HandleTimeoutFailure handles timeout failures.
+func (h *FailureHandler) HandleTimeoutFailure(user *model.User, message string) error {
+	return h.HandleFailure(user, message)
+}

--- a/internal/failure/handler_test.go
+++ b/internal/failure/handler_test.go
@@ -137,7 +137,7 @@ func TestFailureHandler_ResetUserState(t *testing.T) {
 			}
 
 			handler := NewFailureHandler(q)
-			handler.HandleFailure(user, "失敗")
+			_ = handler.HandleFailure(user, "失敗")
 
 			// WaitForで処理完了を待機
 			err := testutil.WaitFor(100*time.Millisecond, 10*time.Millisecond, func() bool {

--- a/internal/failure/handler_test.go
+++ b/internal/failure/handler_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyiku/hackz-ptera-back/internal/model"
-	"github.com/kyiku/hackz-ptera-back/internal/queue"
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/model"
+	"hackz-ptera/back/internal/queue"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/failure/handler_test.go
+++ b/internal/failure/handler_test.go
@@ -73,7 +73,7 @@ func TestFailureHandler_HandleFailure(t *testing.T) {
 
 			// WaitForで接続が閉じられることを確認
 			err = testutil.WaitFor(100*time.Millisecond, 10*time.Millisecond, func() bool {
-				return mockConn.IsClosed
+				return mockConn.GetIsClosed()
 			})
 			require.NoError(t, err, "WebSocket接続が閉じられるべき")
 
@@ -141,7 +141,7 @@ func TestFailureHandler_ResetUserState(t *testing.T) {
 
 			// WaitForで処理完了を待機
 			err := testutil.WaitFor(100*time.Millisecond, 10*time.Millisecond, func() bool {
-				return mockConn.IsClosed
+				return mockConn.GetIsClosed()
 			})
 			require.NoError(t, err)
 
@@ -182,7 +182,7 @@ func TestFailureHandler_MultipleUsers(t *testing.T) {
 	err := testutil.WaitFor(200*time.Millisecond, 10*time.Millisecond, func() bool {
 		allClosed := true
 		for _, conn := range mockConns {
-			if !conn.IsClosed {
+			if !conn.GetIsClosed() {
 				allClosed = false
 			}
 		}

--- a/internal/fish/dataset.go
+++ b/internal/fish/dataset.go
@@ -1,0 +1,106 @@
+// Package fish provides fish dataset management for OTP verification.
+package fish
+
+import (
+	"errors"
+	"math/rand"
+)
+
+// Fish represents a fish in the dataset.
+type Fish struct {
+	Name     string // Fish name in Japanese (katakana)
+	Filename string // Image filename
+}
+
+// predefinedFish contains the list of fish available for OTP.
+var predefinedFish = []Fish{
+	{Name: "オニカマス", Filename: "onikamasu.jpg"},
+	{Name: "ホウボウ", Filename: "houbou.jpg"},
+	{Name: "マツカサウオ", Filename: "matsukasauo.jpg"},
+	{Name: "ハリセンボン", Filename: "harisenbon.jpg"},
+	{Name: "カワハギ", Filename: "kawahagi.jpg"},
+	{Name: "フグ", Filename: "fugu.jpg"},
+	{Name: "タツノオトシゴ", Filename: "tatsunootoshigo.jpg"},
+	{Name: "オコゼ", Filename: "okoze.jpg"},
+	{Name: "アンコウ", Filename: "ankou.jpg"},
+	{Name: "ウツボ", Filename: "utsubo.jpg"},
+	{Name: "ハモ", Filename: "hamo.jpg"},
+	{Name: "カサゴ", Filename: "kasago.jpg"},
+	{Name: "メバル", Filename: "mebaru.jpg"},
+	{Name: "アイナメ", Filename: "ainame.jpg"},
+	{Name: "カレイ", Filename: "karei.jpg"},
+	{Name: "ヒラメ", Filename: "hirame.jpg"},
+	{Name: "タイ", Filename: "tai.jpg"},
+	{Name: "スズキ", Filename: "suzuki.jpg"},
+	{Name: "アジ", Filename: "aji.jpg"},
+	{Name: "サバ", Filename: "saba.jpg"},
+}
+
+// Dataset manages the fish dataset.
+type Dataset struct {
+	fish []Fish
+}
+
+// NewDataset creates a new fish dataset.
+func NewDataset() *Dataset {
+	return &Dataset{
+		fish: predefinedFish,
+	}
+}
+
+// GetRandom returns a random fish from the dataset.
+func (d *Dataset) GetRandom() (*Fish, error) {
+	if len(d.fish) == 0 {
+		return nil, errors.New("no fish available")
+	}
+	idx := rand.Intn(len(d.fish))
+	fish := d.fish[idx]
+	return &fish, nil
+}
+
+// GetRandomExcluding returns a random fish excluding the specified names.
+func (d *Dataset) GetRandomExcluding(excluded []string) (*Fish, error) {
+	excludeMap := make(map[string]bool)
+	for _, name := range excluded {
+		excludeMap[name] = true
+	}
+
+	available := make([]Fish, 0)
+	for _, f := range d.fish {
+		if !excludeMap[f.Name] {
+			available = append(available, f)
+		}
+	}
+
+	if len(available) == 0 {
+		return nil, errors.New("no fish available after exclusion")
+	}
+
+	idx := rand.Intn(len(available))
+	fish := available[idx]
+	return &fish, nil
+}
+
+// Count returns the number of fish in the dataset.
+func (d *Dataset) Count() int {
+	return len(d.fish)
+}
+
+// GetByName returns a fish by its name.
+func (d *Dataset) GetByName(name string) (*Fish, error) {
+	for _, f := range d.fish {
+		if f.Name == name {
+			return &f, nil
+		}
+	}
+	return nil, errors.New("fish not found: " + name)
+}
+
+// ListAll returns all fish in the dataset.
+func (d *Dataset) ListAll() []*Fish {
+	result := make([]*Fish, len(d.fish))
+	for i := range d.fish {
+		result[i] = &d.fish[i]
+	}
+	return result
+}

--- a/internal/game/captcha_timeout.go
+++ b/internal/game/captcha_timeout.go
@@ -1,0 +1,99 @@
+// Package game provides game-related functionality like timeouts.
+package game
+
+import (
+	"sync"
+	"time"
+
+	"hackz-ptera/back/internal/model"
+)
+
+// CaptchaTimeout manages the CAPTCHA challenge timeout.
+type CaptchaTimeout struct {
+	mu       sync.Mutex
+	user     *model.User
+	timeout  time.Duration
+	timer    *time.Timer
+	running  bool
+	canceled bool
+	queue    QueueInterface
+}
+
+// NewCaptchaTimeout creates a new CaptchaTimeout for a user.
+func NewCaptchaTimeout(user *model.User, timeout time.Duration) *CaptchaTimeout {
+	return &CaptchaTimeout{
+		user:    user,
+		timeout: timeout,
+	}
+}
+
+// SetQueue sets the waiting queue.
+func (t *CaptchaTimeout) SetQueue(queue QueueInterface) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.queue = queue
+}
+
+// Start begins the timeout countdown.
+func (t *CaptchaTimeout) Start() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.running = true
+	t.canceled = false
+	t.timer = time.AfterFunc(t.timeout, t.handleTimeout)
+}
+
+// Cancel stops the timeout (called when user completes the CAPTCHA).
+func (t *CaptchaTimeout) Cancel() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.canceled = true
+	t.running = false
+	if t.timer != nil {
+		t.timer.Stop()
+	}
+}
+
+// IsRunning returns whether the timeout is currently running.
+func (t *CaptchaTimeout) IsRunning() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.running
+}
+
+// handleTimeout is called when the timeout expires.
+func (t *CaptchaTimeout) handleTimeout() {
+	t.mu.Lock()
+	if t.canceled {
+		t.mu.Unlock()
+		return
+	}
+	t.running = false
+	user := t.user
+	queue := t.queue
+	t.mu.Unlock()
+
+	// Send failure message
+	if user.Conn != nil {
+		user.Conn.WriteJSON(map[string]interface{}{
+			"type":           "failure",
+			"message":        "タイムアウト！待機列の最後尾からやり直しです。",
+			"redirect_delay": float64(3),
+		})
+	}
+
+	// Reset user state
+	user.ResetToWaiting()
+
+	// Add back to queue
+	if queue != nil {
+		queue.Add(user.ID, user.Conn)
+	}
+
+	// Close connection
+	if user.Conn != nil {
+		user.Conn.Close()
+	}
+}

--- a/internal/game/captcha_timeout.go
+++ b/internal/game/captcha_timeout.go
@@ -77,7 +77,7 @@ func (t *CaptchaTimeout) handleTimeout() {
 
 	// Send failure message
 	if user.Conn != nil {
-		user.Conn.WriteJSON(map[string]interface{}{
+		_ = user.Conn.WriteJSON(map[string]interface{}{
 			"type":           "failure",
 			"message":        "タイムアウト！待機列の最後尾からやり直しです。",
 			"redirect_delay": float64(3),
@@ -94,6 +94,6 @@ func (t *CaptchaTimeout) handleTimeout() {
 
 	// Close connection
 	if user.Conn != nil {
-		user.Conn.Close()
+		_ = user.Conn.Close()
 	}
 }

--- a/internal/game/captcha_timeout_test.go
+++ b/internal/game/captcha_timeout_test.go
@@ -77,7 +77,7 @@ func TestCaptchaTimeout_Cancel(t *testing.T) {
 
 			// WaitForで接続状態を確認（閉じていないことを確認）
 			err := testutil.WaitFor(100*time.Millisecond, 10*time.Millisecond, func() bool {
-				return mockConn.IsClosed == tt.wantConnClosed
+				return mockConn.GetIsClosed() == tt.wantConnClosed
 			})
 			require.NoError(t, err, "接続状態が期待通りにならなかった")
 		})
@@ -120,7 +120,7 @@ func TestCaptchaTimeout_Expire(t *testing.T) {
 
 			// WaitForでタイムアウト処理完了を待機
 			err := testutil.WaitFor(200*time.Millisecond, 10*time.Millisecond, func() bool {
-				return mockConn.IsClosed
+				return mockConn.GetIsClosed()
 			})
 			require.NoError(t, err, "タイムアウト処理が完了しなかった")
 
@@ -133,7 +133,7 @@ func TestCaptchaTimeout_Expire(t *testing.T) {
 			assert.Equal(t, float64(3), msg["redirect_delay"])
 
 			// 接続が閉じられたことを確認
-			assert.Equal(t, tt.wantConnClosed, mockConn.IsClosed)
+			assert.Equal(t, tt.wantConnClosed, mockConn.GetIsClosed())
 
 			// 待機列に追加されたことを確認
 			if tt.wantQueueReset {
@@ -173,7 +173,7 @@ func TestCaptchaTimeout_MultipleUsers(t *testing.T) {
 	err := testutil.WaitFor(200*time.Millisecond, 10*time.Millisecond, func() bool {
 		allClosed := true
 		for _, conn := range mockConns {
-			if !conn.IsClosed {
+			if !conn.GetIsClosed() {
 				allClosed = false
 			}
 		}

--- a/internal/game/captcha_timeout_test.go
+++ b/internal/game/captcha_timeout_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyiku/hackz-ptera-back/internal/model"
-	"github.com/kyiku/hackz-ptera-back/internal/queue"
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/model"
+	"hackz-ptera/back/internal/queue"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/game/dino_timeout.go
+++ b/internal/game/dino_timeout.go
@@ -82,7 +82,7 @@ func (t *DinoTimeout) handleTimeout() {
 
 	// Send failure message
 	if user.Conn != nil {
-		user.Conn.WriteJSON(map[string]interface{}{
+		_ = user.Conn.WriteJSON(map[string]interface{}{
 			"type":           "failure",
 			"message":        "タイムアウト！待機列の最後尾からやり直しです。",
 			"redirect_delay": float64(3),
@@ -99,6 +99,6 @@ func (t *DinoTimeout) handleTimeout() {
 
 	// Close connection
 	if user.Conn != nil {
-		user.Conn.Close()
+		_ = user.Conn.Close()
 	}
 }

--- a/internal/game/dino_timeout.go
+++ b/internal/game/dino_timeout.go
@@ -1,0 +1,104 @@
+// Package game provides game-related functionality like timeouts.
+package game
+
+import (
+	"sync"
+	"time"
+
+	"hackz-ptera/back/internal/model"
+)
+
+// QueueInterface defines the interface for the waiting queue.
+type QueueInterface interface {
+	Add(userID string, conn model.WebSocketConn)
+}
+
+// DinoTimeout manages the Dino Run game timeout.
+type DinoTimeout struct {
+	mu       sync.Mutex
+	user     *model.User
+	timeout  time.Duration
+	timer    *time.Timer
+	running  bool
+	canceled bool
+	queue    QueueInterface
+}
+
+// NewDinoTimeout creates a new DinoTimeout for a user.
+func NewDinoTimeout(user *model.User, timeout time.Duration) *DinoTimeout {
+	return &DinoTimeout{
+		user:    user,
+		timeout: timeout,
+	}
+}
+
+// SetQueue sets the waiting queue.
+func (t *DinoTimeout) SetQueue(queue QueueInterface) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.queue = queue
+}
+
+// Start begins the timeout countdown.
+func (t *DinoTimeout) Start() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.running = true
+	t.canceled = false
+	t.timer = time.AfterFunc(t.timeout, t.handleTimeout)
+}
+
+// Cancel stops the timeout (called when user completes the game).
+func (t *DinoTimeout) Cancel() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.canceled = true
+	t.running = false
+	if t.timer != nil {
+		t.timer.Stop()
+	}
+}
+
+// IsRunning returns whether the timeout is currently running.
+func (t *DinoTimeout) IsRunning() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.running
+}
+
+// handleTimeout is called when the timeout expires.
+func (t *DinoTimeout) handleTimeout() {
+	t.mu.Lock()
+	if t.canceled {
+		t.mu.Unlock()
+		return
+	}
+	t.running = false
+	user := t.user
+	queue := t.queue
+	t.mu.Unlock()
+
+	// Send failure message
+	if user.Conn != nil {
+		user.Conn.WriteJSON(map[string]interface{}{
+			"type":           "failure",
+			"message":        "タイムアウト！待機列の最後尾からやり直しです。",
+			"redirect_delay": float64(3),
+		})
+	}
+
+	// Reset user state
+	user.ResetToWaiting()
+
+	// Add back to queue
+	if queue != nil {
+		queue.Add(user.ID, user.Conn)
+	}
+
+	// Close connection
+	if user.Conn != nil {
+		user.Conn.Close()
+	}
+}

--- a/internal/game/dino_timeout_test.go
+++ b/internal/game/dino_timeout_test.go
@@ -61,12 +61,12 @@ func TestDinoTimeout_Cancel(t *testing.T) {
 
 	// WaitForで接続状態を確認（閉じていないことを確認）
 	err := testutil.WaitFor(100*time.Millisecond, 10*time.Millisecond, func() bool {
-		return mockConn.IsClosed
+		return mockConn.GetIsClosed()
 	})
 
 	// エラーになることを期待（接続が閉じられていない）
 	assert.Error(t, err, "キャンセル後は接続が閉じられないべき")
-	assert.False(t, mockConn.IsClosed)
+	assert.False(t, mockConn.GetIsClosed())
 }
 
 func TestDinoTimeout_Expire(t *testing.T) {
@@ -105,7 +105,7 @@ func TestDinoTimeout_Expire(t *testing.T) {
 
 			// WaitForでタイムアウト処理完了を待機
 			err := testutil.WaitFor(200*time.Millisecond, 10*time.Millisecond, func() bool {
-				return mockConn.IsClosed
+				return mockConn.GetIsClosed()
 			})
 			require.NoError(t, err, "タイムアウト処理が完了しなかった")
 
@@ -118,7 +118,7 @@ func TestDinoTimeout_Expire(t *testing.T) {
 			assert.Equal(t, float64(3), msg["redirect_delay"])
 
 			// 接続が閉じられたことを確認
-			assert.Equal(t, tt.wantConnClosed, mockConn.IsClosed)
+			assert.Equal(t, tt.wantConnClosed, mockConn.GetIsClosed())
 
 			// 待機列に追加されたことを確認
 			if tt.wantQueueReset {
@@ -158,7 +158,7 @@ func TestDinoTimeout_MultipleUsers(t *testing.T) {
 	err := testutil.WaitFor(200*time.Millisecond, 10*time.Millisecond, func() bool {
 		allClosed := true
 		for _, conn := range mockConns {
-			if !conn.IsClosed {
+			if !conn.GetIsClosed() {
 				allClosed = false
 			}
 		}

--- a/internal/game/dino_timeout_test.go
+++ b/internal/game/dino_timeout_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyiku/hackz-ptera-back/internal/model"
-	"github.com/kyiku/hackz-ptera-back/internal/queue"
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/model"
+	"hackz-ptera/back/internal/queue"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/handler/captcha.go
+++ b/internal/handler/captcha.go
@@ -1,0 +1,289 @@
+// Package handler provides HTTP handlers for the API.
+package handler
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/draw"
+	"image/png"
+	"math"
+	"math/rand"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"hackz-ptera/back/internal/model"
+)
+
+// SessionStoreInterface defines the interface for session storage.
+type SessionStoreInterface interface {
+	Get(sessionID string) (*model.User, bool)
+}
+
+// S3ClientInterface defines the interface for S3 operations.
+type S3ClientInterface interface {
+	GetObject(key string) ([]byte, error)
+	PutObject(key string, data []byte) error
+	ListObjects(prefix string) ([]string, error)
+}
+
+// QueueInterfaceForCaptcha defines the queue interface for CAPTCHA handler.
+type QueueInterfaceForCaptcha interface {
+	Add(userID string, conn model.WebSocketConn)
+}
+
+// CaptchaHandler handles CAPTCHA-related requests.
+type CaptchaHandler struct {
+	store         SessionStoreInterface
+	s3Client      S3ClientInterface
+	queue         QueueInterfaceForCaptcha
+	tolerance     int
+	cloudfrontURL string
+}
+
+// NewCaptchaHandler creates a new CaptchaHandler.
+func NewCaptchaHandler(store SessionStoreInterface, s3Client S3ClientInterface) *CaptchaHandler {
+	return &CaptchaHandler{
+		store:         store,
+		s3Client:      s3Client,
+		tolerance:     10, // default tolerance
+		cloudfrontURL: "https://test.cloudfront.net",
+	}
+}
+
+// SetQueue sets the waiting queue.
+func (h *CaptchaHandler) SetQueue(queue QueueInterfaceForCaptcha) {
+	h.queue = queue
+}
+
+// SetTolerance sets the click tolerance in pixels.
+func (h *CaptchaHandler) SetTolerance(tolerance int) {
+	h.tolerance = tolerance
+}
+
+// Generate creates a new CAPTCHA image.
+func (h *CaptchaHandler) Generate(c echo.Context) error {
+	// Get session
+	cookie, err := c.Cookie("session_id")
+	if err != nil || cookie == nil {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "セッションが見つかりません",
+		})
+	}
+
+	user, ok := h.store.Get(cookie.Value)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "無効なセッション",
+		})
+	}
+
+	// Check user status
+	if user.Status != "stage2_captcha" {
+		return c.JSON(http.StatusForbidden, map[string]interface{}{
+			"error":   true,
+			"message": "CAPTCHAステージではありません",
+		})
+	}
+
+	// Generate CAPTCHA image
+	imgURL, targetX, targetY, err := h.generateCaptchaImage()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"error":   true,
+			"message": "CAPTCHA生成に失敗しました",
+		})
+	}
+
+	// Save target position
+	user.CaptchaTargetX = targetX
+	user.CaptchaTargetY = targetY
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"error":     false,
+		"image_url": imgURL,
+	})
+}
+
+// VerifyRequest represents the CAPTCHA verification request.
+type VerifyRequest struct {
+	X int `json:"x"`
+	Y int `json:"y"`
+}
+
+// Verify checks the CAPTCHA answer.
+func (h *CaptchaHandler) Verify(c echo.Context) error {
+	// Get session
+	cookie, err := c.Cookie("session_id")
+	if err != nil || cookie == nil {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "セッションが見つかりません",
+		})
+	}
+
+	user, ok := h.store.Get(cookie.Value)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "無効なセッション",
+		})
+	}
+
+	// Parse request
+	var req VerifyRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"error":   true,
+			"message": "リクエストの解析に失敗しました",
+		})
+	}
+
+	// Check if click is within tolerance
+	dx := float64(req.X - user.CaptchaTargetX)
+	dy := float64(req.Y - user.CaptchaTargetY)
+	distance := math.Sqrt(dx*dx + dy*dy)
+
+	if distance <= float64(h.tolerance) {
+		// Success - advance to registering stage
+		user.Status = "registering"
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"error":      false,
+			"next_stage": "registering",
+			"message":    "CAPTCHA成功！登録フォームに進みます",
+		})
+	}
+
+	// Failed attempt
+	exceeded := user.IncrementCaptchaAttempts()
+
+	if exceeded {
+		// 3 failures - reset to waiting
+		return h.handleMaxAttempts(c, user)
+	}
+
+	// Generate new CAPTCHA for retry
+	newImgURL, targetX, targetY, err := h.generateCaptchaImage()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"error":   true,
+			"message": "CAPTCHA再生成に失敗しました",
+		})
+	}
+
+	user.CaptchaTargetX = targetX
+	user.CaptchaTargetY = targetY
+	remaining := model.MaxCaptchaAttempts - user.CaptchaAttempts
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"error":              true,
+		"message":            "不正解です。もう一度試してください",
+		"attempts_remaining": remaining,
+		"new_image_url":      newImgURL,
+	})
+}
+
+// handleMaxAttempts handles the case when max attempts are exceeded.
+func (h *CaptchaHandler) handleMaxAttempts(c echo.Context, user *model.User) error {
+	// Send failure notification via WebSocket
+	if user.Conn != nil {
+		user.Conn.WriteJSON(map[string]interface{}{
+			"type":           "failure",
+			"message":        "3回失敗しました。待機列の最後尾からやり直しです。",
+			"redirect_delay": float64(3),
+		})
+	}
+
+	// Reset user state
+	user.ResetToWaiting()
+
+	// Add back to queue
+	if h.queue != nil {
+		h.queue.Add(user.ID, user.Conn)
+	}
+
+	// Close connection after sending message
+	if user.Conn != nil {
+		go user.Conn.Close()
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"error":          true,
+		"message":        "3回失敗しました。待機列の最後尾からやり直しです。",
+		"redirect_delay": float64(3),
+	})
+}
+
+// generateCaptchaImage creates a CAPTCHA image with hidden character.
+func (h *CaptchaHandler) generateCaptchaImage() (string, int, int, error) {
+	// Get background image
+	bgKeys, err := h.s3Client.ListObjects("backgrounds/")
+	if err != nil || len(bgKeys) == 0 {
+		return "", 0, 0, fmt.Errorf("failed to list backgrounds: %w", err)
+	}
+
+	bgData, err := h.s3Client.GetObject(bgKeys[rand.Intn(len(bgKeys))])
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("failed to get background: %w", err)
+	}
+
+	bgImg, _, err := image.Decode(bytes.NewReader(bgData))
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("failed to decode background: %w", err)
+	}
+
+	// Get character image
+	charData, err := h.s3Client.GetObject("character/char.png")
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("failed to get character: %w", err)
+	}
+
+	charImg, _, err := image.Decode(bytes.NewReader(charData))
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("failed to decode character: %w", err)
+	}
+
+	// Calculate random position
+	bgBounds := bgImg.Bounds()
+	charBounds := charImg.Bounds()
+
+	maxX := bgBounds.Dx() - charBounds.Dx()
+	maxY := bgBounds.Dy() - charBounds.Dy()
+
+	if maxX <= 0 {
+		maxX = 1
+	}
+	if maxY <= 0 {
+		maxY = 1
+	}
+
+	targetX := rand.Intn(maxX)
+	targetY := rand.Intn(maxY)
+
+	// Compose image
+	result := image.NewRGBA(bgBounds)
+	draw.Draw(result, bgBounds, bgImg, bgBounds.Min, draw.Src)
+
+	destRect := image.Rect(targetX, targetY, targetX+charBounds.Dx(), targetY+charBounds.Dy())
+	draw.Draw(result, destRect, charImg, charBounds.Min, draw.Over)
+
+	// Encode to PNG
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, result); err != nil {
+		return "", 0, 0, fmt.Errorf("failed to encode image: %w", err)
+	}
+
+	// Upload to S3
+	filename := uuid.New().String() + ".png"
+	key := "captcha/" + filename
+
+	if err := h.s3Client.PutObject(key, buf.Bytes()); err != nil {
+		return "", 0, 0, fmt.Errorf("failed to upload image: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/%s", h.cloudfrontURL, key)
+	return url, targetX, targetY, nil
+}

--- a/internal/handler/captcha.go
+++ b/internal/handler/captcha.go
@@ -190,7 +190,7 @@ func (h *CaptchaHandler) Verify(c echo.Context) error {
 func (h *CaptchaHandler) handleMaxAttempts(c echo.Context, user *model.User) error {
 	// Send failure notification via WebSocket
 	if user.Conn != nil {
-		user.Conn.WriteJSON(map[string]interface{}{
+		_ = user.Conn.WriteJSON(map[string]interface{}{
 			"type":           "failure",
 			"message":        "3回失敗しました。待機列の最後尾からやり直しです。",
 			"redirect_delay": float64(3),

--- a/internal/handler/captcha_test.go
+++ b/internal/handler/captcha_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/kyiku/hackz-ptera-back/internal/model"
-	"github.com/kyiku/hackz-ptera-back/internal/session"
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/model"
+	"hackz-ptera/back/internal/session"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/handler/captcha_test.go
+++ b/internal/handler/captcha_test.go
@@ -90,7 +90,7 @@ func TestCaptchaHandler_Generate(t *testing.T) {
 			assert.Equal(t, tt.wantStatusCode, tc.Recorder.Code)
 
 			var resp map[string]interface{}
-			json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+			_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 			assert.Equal(t, tt.wantError, resp["error"])
 

--- a/internal/handler/captcha_verify_test.go
+++ b/internal/handler/captcha_verify_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyiku/hackz-ptera-back/internal/model"
-	"github.com/kyiku/hackz-ptera-back/internal/queue"
-	"github.com/kyiku/hackz-ptera-back/internal/session"
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/model"
+	"hackz-ptera/back/internal/queue"
+	"hackz-ptera/back/internal/session"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/handler/captcha_verify_test.go
+++ b/internal/handler/captcha_verify_test.go
@@ -103,6 +103,10 @@ func TestCaptchaHandler_Verify(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			store := session.NewSessionStore()
 			mockS3 := testutil.NewMockS3Client()
+			mockS3.Objects = map[string][]byte{
+				"backgrounds/bg1.png": testutil.CreateTestPNG(1024, 768),
+				"character/char.png":  testutil.CreateTestPNG(8, 8),
+			}
 
 			var sessionID string
 			var user *model.User

--- a/internal/handler/captcha_verify_test.go
+++ b/internal/handler/captcha_verify_test.go
@@ -131,7 +131,7 @@ func TestCaptchaHandler_Verify(t *testing.T) {
 			assert.Equal(t, tt.wantStatusCode, tc.Recorder.Code)
 
 			var resp map[string]interface{}
-			json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+			_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 			assert.Equal(t, tt.wantError, resp["error"])
 
@@ -169,7 +169,7 @@ func TestCaptchaHandler_Verify_ThreeFailures(t *testing.T) {
 	require.NoError(t, err)
 
 	var resp map[string]interface{}
-	json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+	_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 	assert.Equal(t, true, resp["error"])
 	assert.Equal(t, float64(3), resp["redirect_delay"])

--- a/internal/handler/captcha_verify_test.go
+++ b/internal/handler/captcha_verify_test.go
@@ -176,7 +176,7 @@ func TestCaptchaHandler_Verify_ThreeFailures(t *testing.T) {
 
 	// WebSocket接続が閉じられることを確認
 	err = testutil.WaitFor(100*time.Millisecond, 10*time.Millisecond, func() bool {
-		return mockConn.IsClosed
+		return mockConn.GetIsClosed()
 	})
 	require.NoError(t, err)
 

--- a/internal/handler/captcha_verify_test.go
+++ b/internal/handler/captcha_verify_test.go
@@ -221,7 +221,7 @@ func TestCaptchaHandler_Verify_AttemptsRemaining(t *testing.T) {
 			require.NoError(t, err)
 
 			var resp map[string]interface{}
-			json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+			_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 			assert.Equal(t, true, resp["error"])
 			assert.Equal(t, float64(tt.wantRemaining), resp["attempts_remaining"])

--- a/internal/handler/dino.go
+++ b/internal/handler/dino.go
@@ -79,7 +79,7 @@ func (h *DinoHandler) Result(c echo.Context) error {
 
 	// Send failure notification via WebSocket
 	if user.Conn != nil {
-		user.Conn.WriteJSON(map[string]interface{}{
+		_ = user.Conn.WriteJSON(map[string]interface{}{
 			"type":           "failure",
 			"message":        "ゲームオーバー。待機列の最後尾からやり直しです。",
 			"redirect_delay": float64(3),

--- a/internal/handler/dino.go
+++ b/internal/handler/dino.go
@@ -1,0 +1,94 @@
+// Package handler provides HTTP handlers for the API.
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"hackz-ptera/back/internal/model"
+)
+
+// DinoHandler handles Dino Run game related requests.
+type DinoHandler struct {
+	store SessionStoreInterface
+}
+
+// NewDinoHandler creates a new DinoHandler.
+func NewDinoHandler(store SessionStoreInterface) *DinoHandler {
+	return &DinoHandler{
+		store: store,
+	}
+}
+
+// DinoResultRequest represents the game result request.
+type DinoResultRequest struct {
+	Result string `json:"result"`
+	Score  int    `json:"score"`
+}
+
+// Result handles the Dino Run game result.
+func (h *DinoHandler) Result(c echo.Context) error {
+	// Get session
+	cookie, err := c.Cookie("session_id")
+	if err != nil || cookie == nil {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "セッションが見つかりません",
+		})
+	}
+
+	user, ok := h.store.Get(cookie.Value)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "無効なセッション",
+		})
+	}
+
+	// Check user status
+	if user.Status != "stage1_dino" {
+		return c.JSON(http.StatusForbidden, map[string]interface{}{
+			"error":   true,
+			"message": "Dino Runステージではありません",
+		})
+	}
+
+	// Parse request
+	var req DinoResultRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"error":   true,
+			"message": "リクエストの解析に失敗しました",
+		})
+	}
+
+	// Handle result
+	if req.Result == "clear" {
+		// Success - advance to CAPTCHA stage
+		user.Status = model.StatusStage2Captcha
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"error":      false,
+			"next_stage": "stage2_captcha",
+			"message":    "ゲームクリア！CAPTCHAステージに進みます",
+			"score":      req.Score,
+		})
+	}
+
+	// Game over - reset to waiting
+	user.ResetToWaiting()
+
+	// Send failure notification via WebSocket
+	if user.Conn != nil {
+		user.Conn.WriteJSON(map[string]interface{}{
+			"type":           "failure",
+			"message":        "ゲームオーバー。待機列の最後尾からやり直しです。",
+			"redirect_delay": float64(3),
+		})
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"error":          true,
+		"message":        "ゲームオーバー。待機列の最後尾からやり直しです。",
+		"redirect_delay": float64(3),
+	})
+}

--- a/internal/handler/dino_test.go
+++ b/internal/handler/dino_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kyiku/hackz-ptera-back/internal/model"
-	"github.com/kyiku/hackz-ptera-back/internal/session"
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/model"
+	"hackz-ptera/back/internal/session"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/handler/dino_test.go
+++ b/internal/handler/dino_test.go
@@ -114,7 +114,7 @@ func TestDinoHandler_Result(t *testing.T) {
 			assert.Equal(t, tt.wantStatusCode, tc.Recorder.Code)
 
 			var resp map[string]interface{}
-			json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+			_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 			assert.Equal(t, tt.wantError, resp["error"])
 
@@ -143,7 +143,7 @@ func TestDinoHandler_Result_GameOver_QueueReset(t *testing.T) {
 	require.NoError(t, err)
 
 	var resp map[string]interface{}
-	json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+	_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 	assert.Equal(t, true, resp["error"])
 	assert.Equal(t, float64(3), resp["redirect_delay"])

--- a/internal/handler/health.go
+++ b/internal/handler/health.go
@@ -1,0 +1,23 @@
+// Package handler provides HTTP handlers for the API.
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// HealthHandler handles health check requests.
+type HealthHandler struct{}
+
+// NewHealthHandler creates a new HealthHandler.
+func NewHealthHandler() *HealthHandler {
+	return &HealthHandler{}
+}
+
+// Check returns the health status of the server.
+func (h *HealthHandler) Check(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"status": "ok",
+	})
+}

--- a/internal/handler/health_test.go
+++ b/internal/handler/health_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/handler/otp.go
+++ b/internal/handler/otp.go
@@ -1,0 +1,204 @@
+// Package handler provides HTTP handlers for the API.
+package handler
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"hackz-ptera/back/internal/model"
+	"hackz-ptera/back/internal/util"
+)
+
+// OTPHandler handles OTP-related requests.
+type OTPHandler struct {
+	store         SessionStoreInterface
+	s3Client      S3ClientInterface
+	queue         QueueInterfaceForCaptcha
+	cloudfrontURL string
+}
+
+// NewOTPHandler creates a new OTPHandler.
+func NewOTPHandler(store SessionStoreInterface, s3Client S3ClientInterface) *OTPHandler {
+	return &OTPHandler{
+		store:         store,
+		s3Client:      s3Client,
+		cloudfrontURL: "https://test.cloudfront.net",
+	}
+}
+
+// SetQueue sets the waiting queue.
+func (h *OTPHandler) SetQueue(queue QueueInterfaceForCaptcha) {
+	h.queue = queue
+}
+
+// predefinedFish contains the list of fish for OTP.
+var predefinedFish = []struct {
+	Name     string
+	Filename string
+}{
+	{Name: "オニカマス", Filename: "onikamasu"},
+	{Name: "ホウボウ", Filename: "houhou"},
+	{Name: "マツカサウオ", Filename: "matsukasauo"},
+	{Name: "ハリセンボン", Filename: "harisenbon"},
+	{Name: "カワハギ", Filename: "kawahagi"},
+	{Name: "フグ", Filename: "fugu"},
+	{Name: "タツノオトシゴ", Filename: "tatsunootoshigo"},
+	{Name: "オコゼ", Filename: "okoze"},
+	{Name: "アンコウ", Filename: "ankou"},
+	{Name: "ウツボ", Filename: "utsubo"},
+}
+
+// Send generates and sends an OTP fish image.
+func (h *OTPHandler) Send(c echo.Context) error {
+	// Get session
+	cookie, err := c.Cookie("session_id")
+	if err != nil || cookie == nil {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "セッションが見つかりません",
+		})
+	}
+
+	user, ok := h.store.Get(cookie.Value)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "無効なセッション",
+		})
+	}
+
+	// Check user status
+	if user.Status != "registering" {
+		return c.JSON(http.StatusForbidden, map[string]interface{}{
+			"error":   true,
+			"message": "登録ステージではありません",
+		})
+	}
+
+	// Select random fish
+	fish := predefinedFish[rand.Intn(len(predefinedFish))]
+
+	// Save fish name for verification
+	user.OTPFishName = fish.Name
+	user.OTPAttempts = 0
+
+	// Generate image URL
+	imageURL := fmt.Sprintf("%s/fish/%s.jpg", h.cloudfrontURL, fish.Filename)
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"error":     false,
+		"image_url": imageURL,
+		"message":   "この魚の名前を入力してください",
+	})
+}
+
+// OTPVerifyRequest represents the OTP verification request.
+type OTPVerifyRequest struct {
+	Answer string `json:"answer"`
+}
+
+// Verify checks the OTP answer.
+func (h *OTPHandler) Verify(c echo.Context) error {
+	// Get session
+	cookie, err := c.Cookie("session_id")
+	if err != nil || cookie == nil {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "セッションが見つかりません",
+		})
+	}
+
+	user, ok := h.store.Get(cookie.Value)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "無効なセッション",
+		})
+	}
+
+	// Parse request
+	var req OTPVerifyRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"error":   true,
+			"message": "リクエストの解析に失敗しました",
+		})
+	}
+
+	// Check answer using kana-insensitive matching
+	if util.KanaMatch(req.Answer, user.OTPFishName) {
+		// Success - registration complete
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"error":   false,
+			"message": "正解です！登録が完了しました",
+		})
+	}
+
+	// Failed attempt
+	exceeded := user.IncrementOTPAttempts()
+
+	if exceeded {
+		// 3 failures - reset to waiting
+		return h.handleMaxAttempts(c, user)
+	}
+
+	// Generate new fish for retry
+	fish := h.getRandomFishExcluding(user.OTPFishName)
+	user.OTPFishName = fish.Name
+
+	remaining := model.MaxOTPAttempts - user.OTPAttempts
+	imageURL := fmt.Sprintf("%s/fish/%s.jpg", h.cloudfrontURL, fish.Filename)
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"error":              true,
+		"message":            "不正解です。もう一度試してください",
+		"attempts_remaining": remaining,
+		"new_image_url":      imageURL,
+	})
+}
+
+// handleMaxAttempts handles the case when max OTP attempts are exceeded.
+func (h *OTPHandler) handleMaxAttempts(c echo.Context, user *model.User) error {
+	// Send failure notification via WebSocket
+	if user.Conn != nil {
+		user.Conn.WriteJSON(map[string]interface{}{
+			"type":           "failure",
+			"message":        "魚の名前を3回間違えました。",
+			"redirect_delay": float64(3),
+		})
+	}
+
+	// Reset user state
+	user.ResetToWaiting()
+
+	// Add back to queue
+	if h.queue != nil {
+		h.queue.Add(user.ID, user.Conn)
+	}
+
+	// Close connection after sending message
+	if user.Conn != nil {
+		go user.Conn.Close()
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"error":          true,
+		"message":        "魚の名前を3回間違えました。",
+		"redirect_delay": float64(3),
+	})
+}
+
+// getRandomFishExcluding returns a random fish excluding the specified name.
+func (h *OTPHandler) getRandomFishExcluding(excludeName string) struct {
+	Name     string
+	Filename string
+} {
+	for {
+		fish := predefinedFish[rand.Intn(len(predefinedFish))]
+		if fish.Name != excludeName {
+			return fish
+		}
+	}
+}

--- a/internal/handler/otp.go
+++ b/internal/handler/otp.go
@@ -163,7 +163,7 @@ func (h *OTPHandler) Verify(c echo.Context) error {
 func (h *OTPHandler) handleMaxAttempts(c echo.Context, user *model.User) error {
 	// Send failure notification via WebSocket
 	if user.Conn != nil {
-		user.Conn.WriteJSON(map[string]interface{}{
+		_ = user.Conn.WriteJSON(map[string]interface{}{
 			"type":           "failure",
 			"message":        "魚の名前を3回間違えました。",
 			"redirect_delay": float64(3),

--- a/internal/handler/otp_test.go
+++ b/internal/handler/otp_test.go
@@ -289,7 +289,7 @@ func TestOTPHandler_Verify_Failure(t *testing.T) {
 			if tt.wantConnClosed {
 				// WaitForで接続が閉じられることを確認
 				err := testutil.WaitFor(100*time.Millisecond, 10*time.Millisecond, func() bool {
-					return mockConn.IsClosed
+					return mockConn.GetIsClosed()
 				})
 				require.NoError(t, err, "WebSocket接続が閉じられるべき")
 			}

--- a/internal/handler/otp_test.go
+++ b/internal/handler/otp_test.go
@@ -106,7 +106,7 @@ func TestOTPHandler_Send(t *testing.T) {
 			assert.Equal(t, tt.wantStatusCode, tc.Recorder.Code)
 
 			var resp map[string]interface{}
-			json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+			_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 			assert.Equal(t, tt.wantError, resp["error"])
 
@@ -186,7 +186,7 @@ func TestOTPHandler_Verify_Success(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, tc.Recorder.Code)
 
 			var resp map[string]interface{}
-			json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+			_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 			assert.Equal(t, tt.wantError, resp["error"])
 		})
@@ -272,7 +272,7 @@ func TestOTPHandler_Verify_Failure(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, tc.Recorder.Code)
 
 			var resp map[string]interface{}
-			json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+			_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 			assert.True(t, resp["error"].(bool))
 

--- a/internal/handler/otp_test.go
+++ b/internal/handler/otp_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyiku/hackz-ptera-back/internal/model"
-	"github.com/kyiku/hackz-ptera-back/internal/queue"
-	"github.com/kyiku/hackz-ptera-back/internal/session"
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/model"
+	"hackz-ptera/back/internal/queue"
+	"hackz-ptera/back/internal/session"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/handler/password.go
+++ b/internal/handler/password.go
@@ -15,9 +15,8 @@ type BedrockClientInterface interface {
 
 // PasswordHandler handles password analysis requests.
 type PasswordHandler struct {
-	store           SessionStoreInterface
-	bedrockClient   *ai.BedrockClient
-	fallbackEnabled bool
+	store         SessionStoreInterface
+	bedrockClient *ai.BedrockClient
 }
 
 // NewPasswordHandler creates a new PasswordHandler.

--- a/internal/handler/password.go
+++ b/internal/handler/password.go
@@ -1,0 +1,99 @@
+// Package handler provides HTTP handlers for the API.
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"hackz-ptera/back/internal/ai"
+)
+
+// BedrockClientInterface defines the interface for Bedrock operations.
+type BedrockClientInterface interface {
+	InvokeModel(modelID string, prompt string) (string, error)
+}
+
+// PasswordHandler handles password analysis requests.
+type PasswordHandler struct {
+	store           SessionStoreInterface
+	bedrockClient   *ai.BedrockClient
+	fallbackEnabled bool
+}
+
+// NewPasswordHandler creates a new PasswordHandler.
+func NewPasswordHandler(store SessionStoreInterface, bedrockClient BedrockClientInterface) *PasswordHandler {
+	client := ai.NewBedrockClient(bedrockClient, "ap-northeast-1")
+	return &PasswordHandler{
+		store:         store,
+		bedrockClient: client,
+	}
+}
+
+// EnableFallback enables or disables fallback mode.
+func (h *PasswordHandler) EnableFallback(enabled bool) {
+	h.bedrockClient.EnableFallback(enabled)
+}
+
+// PasswordAnalyzeRequest represents the password analysis request.
+type PasswordAnalyzeRequest struct {
+	Password string `json:"password"`
+}
+
+// Analyze analyzes a password using AI.
+func (h *PasswordHandler) Analyze(c echo.Context) error {
+	// Get session
+	cookie, err := c.Cookie("session_id")
+	if err != nil || cookie == nil {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "セッションが見つかりません",
+		})
+	}
+
+	user, ok := h.store.Get(cookie.Value)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "無効なセッション",
+		})
+	}
+
+	// Check user status
+	if user.Status != "registering" {
+		return c.JSON(http.StatusForbidden, map[string]interface{}{
+			"error":   true,
+			"message": "登録ステージではありません",
+		})
+	}
+
+	// Parse request
+	var req PasswordAnalyzeRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"error":   true,
+			"message": "リクエストの解析に失敗しました",
+		})
+	}
+
+	// Validate password
+	if req.Password == "" {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"error":   true,
+			"message": "パスワードが空です",
+		})
+	}
+
+	// Analyze password using Bedrock
+	analysis, err := h.bedrockClient.AnalyzePassword(req.Password)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"error":   true,
+			"message": "パスワード分析に失敗しました",
+		})
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"error":    false,
+		"analysis": analysis,
+	})
+}

--- a/internal/handler/password_test.go
+++ b/internal/handler/password_test.go
@@ -114,7 +114,7 @@ func TestPasswordHandler_Analyze(t *testing.T) {
 			assert.Equal(t, tt.wantStatusCode, tc.Recorder.Code)
 
 			var resp map[string]interface{}
-			json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+			_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 			assert.Equal(t, tt.wantError, resp["error"])
 
@@ -173,7 +173,7 @@ func TestPasswordHandler_Analyze_Fallback(t *testing.T) {
 	assert.Equal(t, http.StatusOK, tc.Recorder.Code)
 
 	var resp map[string]interface{}
-	json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+	_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 	// フォールバックメッセージが返される
 	assert.False(t, resp["error"].(bool))

--- a/internal/handler/password_test.go
+++ b/internal/handler/password_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kyiku/hackz-ptera-back/internal/model"
-	"github.com/kyiku/hackz-ptera-back/internal/session"
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/model"
+	"hackz-ptera/back/internal/session"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/handler/password_test.go
+++ b/internal/handler/password_test.go
@@ -142,7 +142,7 @@ func TestPasswordHandler_Analyze_BedrockPrompt(t *testing.T) {
 	tc.Request.Header.Set("Content-Type", "application/json")
 	tc.Request.AddCookie(&http.Cookie{Name: "session_id", Value: sessionID})
 
-	h.Analyze(tc.Context)
+	_ = h.Analyze(tc.Context)
 
 	// プロンプトにパスワードが含まれていることを確認
 	assert.Contains(t, mockBedrock.LastPrompt, "mySecretPass123")

--- a/internal/handler/register.go
+++ b/internal/handler/register.go
@@ -1,0 +1,108 @@
+// Package handler provides HTTP handlers for the API.
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"hackz-ptera/back/internal/model"
+)
+
+// RegisterHandler handles registration requests.
+type RegisterHandler struct {
+	store SessionStoreInterface
+	queue QueueInterfaceForCaptcha
+}
+
+// NewRegisterHandler creates a new RegisterHandler.
+func NewRegisterHandler(store SessionStoreInterface) *RegisterHandler {
+	return &RegisterHandler{
+		store: store,
+	}
+}
+
+// SetQueue sets the waiting queue.
+func (h *RegisterHandler) SetQueue(queue QueueInterfaceForCaptcha) {
+	h.queue = queue
+}
+
+// RegisterRequest represents the registration request.
+type RegisterRequest struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+	Token    string `json:"token"`
+}
+
+// Submit handles the registration form submission.
+// This is the "evil" handler - it ALWAYS fails with a server error.
+func (h *RegisterHandler) Submit(c echo.Context) error {
+	// Get session
+	cookie, err := c.Cookie("session_id")
+	if err != nil || cookie == nil {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "セッションが見つかりません",
+		})
+	}
+
+	user, ok := h.store.Get(cookie.Value)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+			"error":   true,
+			"message": "無効なセッション",
+		})
+	}
+
+	// Check user status
+	if user.Status != "registering" {
+		return c.JSON(http.StatusForbidden, map[string]interface{}{
+			"error":   true,
+			"message": "登録ステージではありません",
+		})
+	}
+
+	// Parse request
+	var req RegisterRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"error":   true,
+			"message": "リクエストの解析に失敗しました",
+		})
+	}
+
+	// EVIL: Always fail with server error
+	// This is the joke - the registration never succeeds
+	return h.handleFakeServerError(c, user)
+}
+
+// handleFakeServerError simulates a server error and resets the user.
+func (h *RegisterHandler) handleFakeServerError(c echo.Context, user *model.User) error {
+	// Send failure notification via WebSocket
+	if user.Conn != nil {
+		user.Conn.WriteJSON(map[string]interface{}{
+			"type":           "failure",
+			"message":        "サーバーエラーが発生しました。待機列の最後尾からやり直しです。",
+			"redirect_delay": float64(3),
+		})
+	}
+
+	// Reset user state
+	user.ResetToWaiting()
+
+	// Add back to queue
+	if h.queue != nil {
+		h.queue.Add(user.ID, user.Conn)
+	}
+
+	// Close connection after sending message
+	if user.Conn != nil {
+		go user.Conn.Close()
+	}
+
+	return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+		"error":          true,
+		"message":        "サーバーエラーが発生しました。待機列の最後尾からやり直しです。",
+		"redirect_delay": float64(3),
+	})
+}

--- a/internal/handler/register.go
+++ b/internal/handler/register.go
@@ -80,7 +80,7 @@ func (h *RegisterHandler) Submit(c echo.Context) error {
 func (h *RegisterHandler) handleFakeServerError(c echo.Context, user *model.User) error {
 	// Send failure notification via WebSocket
 	if user.Conn != nil {
-		user.Conn.WriteJSON(map[string]interface{}{
+		_ = user.Conn.WriteJSON(map[string]interface{}{
 			"type":           "failure",
 			"message":        "サーバーエラーが発生しました。待機列の最後尾からやり直しです。",
 			"redirect_delay": float64(3),

--- a/internal/handler/register_test.go
+++ b/internal/handler/register_test.go
@@ -205,7 +205,7 @@ func TestRegisterHandler_QueueReset(t *testing.T) {
 	tc.Request.Header.Set("Content-Type", "application/json")
 	tc.Request.AddCookie(&http.Cookie{Name: "session_id", Value: sessionID})
 
-	h.Submit(tc.Context)
+	_ = h.Submit(tc.Context)
 
 	// 待機列に追加されたことを確認
 	err := testutil.WaitFor(100*time.Millisecond, 10*time.Millisecond, func() bool {
@@ -241,7 +241,7 @@ func TestRegisterHandler_WebSocketFailureMessage(t *testing.T) {
 	tc.Request.Header.Set("Content-Type", "application/json")
 	tc.Request.AddCookie(&http.Cookie{Name: "session_id", Value: sessionID})
 
-	h.Submit(tc.Context)
+	_ = h.Submit(tc.Context)
 
 	// WebSocket経由でfailureメッセージが送信されることを確認
 	msg := testutil.WaitForMessage(mockConn, 100*time.Millisecond)

--- a/internal/handler/register_test.go
+++ b/internal/handler/register_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyiku/hackz-ptera-back/internal/model"
-	"github.com/kyiku/hackz-ptera-back/internal/queue"
-	"github.com/kyiku/hackz-ptera-back/internal/session"
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/model"
+	"hackz-ptera/back/internal/queue"
+	"hackz-ptera/back/internal/session"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/handler/register_test.go
+++ b/internal/handler/register_test.go
@@ -122,7 +122,7 @@ func TestRegisterHandler_Submit(t *testing.T) {
 
 			if tt.wantConnClosed && mockConn != nil {
 				err := testutil.WaitFor(100*time.Millisecond, 10*time.Millisecond, func() bool {
-					return mockConn.IsClosed
+					return mockConn.GetIsClosed()
 				})
 				require.NoError(t, err, "WebSocket接続が閉じられるべき")
 			}

--- a/internal/handler/register_test.go
+++ b/internal/handler/register_test.go
@@ -112,7 +112,7 @@ func TestRegisterHandler_Submit(t *testing.T) {
 			assert.Equal(t, tt.wantStatusCode, tc.Recorder.Code)
 
 			var resp map[string]interface{}
-			json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+			_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 			assert.Equal(t, tt.wantError, resp["error"])
 
@@ -174,7 +174,7 @@ func TestRegisterHandler_AlwaysFails(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, tc.Recorder.Code)
 
 		var resp map[string]interface{}
-		json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+		_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 		assert.True(t, resp["error"].(bool))
 		assert.Contains(t, resp["message"], "サーバーエラー")

--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -1,0 +1,71 @@
+// Package handler provides HTTP handlers for the API.
+package handler
+
+import (
+	"errors"
+
+	"github.com/labstack/echo/v4"
+	"hackz-ptera/back/internal/model"
+	"hackz-ptera/back/internal/queue"
+)
+
+// WebSocketHandler handles WebSocket connections.
+type WebSocketHandler struct {
+	store SessionStoreInterface
+	queue *queue.WaitingQueue
+}
+
+// NewWebSocketHandler creates a new WebSocketHandler.
+func NewWebSocketHandler(store SessionStoreInterface, q *queue.WaitingQueue) *WebSocketHandler {
+	return &WebSocketHandler{
+		store: store,
+		queue: q,
+	}
+}
+
+// ValidateSession validates the session for WebSocket connection.
+func (h *WebSocketHandler) ValidateSession(c echo.Context) error {
+	cookie, err := c.Cookie("session_id")
+	if err != nil || cookie == nil {
+		return errors.New("no session cookie")
+	}
+
+	_, ok := h.store.Get(cookie.Value)
+	if !ok {
+		return errors.New("invalid session")
+	}
+
+	return nil
+}
+
+// Connect handles the WebSocket upgrade and connection.
+// Note: This is a simplified version. Real implementation would use gorilla/websocket.
+func (h *WebSocketHandler) Connect(c echo.Context) error {
+	// Validate session first
+	if err := h.ValidateSession(c); err != nil {
+		return c.JSON(401, map[string]interface{}{
+			"error":   true,
+			"message": "セッションが無効です",
+		})
+	}
+
+	// Get session
+	cookie, _ := c.Cookie("session_id")
+	user, _ := h.store.Get(cookie.Value)
+
+	// Add user to queue (simplified - real impl would handle WebSocket upgrade)
+	h.queue.Add(user.ID, user.Conn)
+
+	// Broadcast queue positions
+	h.queue.BroadcastPositions()
+
+	return nil
+}
+
+// Disconnect handles WebSocket disconnection.
+func (h *WebSocketHandler) Disconnect(user *model.User) {
+	if user != nil {
+		h.queue.Remove(user.ID)
+		h.queue.BroadcastPositions()
+	}
+}

--- a/internal/handler/websocket_test.go
+++ b/internal/handler/websocket_test.go
@@ -116,7 +116,7 @@ func TestWebSocketHandler_QueueUpdate(t *testing.T) {
 			// ユーザーを追加
 			for i := 0; i < tt.usersInQueue; i++ {
 				mockConns[i] = testutil.NewMockWebSocketConn()
-				q.Add(&queue.QueueUser{
+				q.AddUser(&queue.QueueUser{
 					ID:   string(rune('a' + i)),
 					Conn: mockConns[i],
 				})
@@ -145,13 +145,12 @@ func TestWebSocketHandler_Disconnect(t *testing.T) {
 	store := session.NewSessionStore()
 	q := queue.NewWaitingQueue()
 
-	user, sessionID := store.Create()
+	user, _ := store.Create()
 	mockConn := testutil.NewMockWebSocketConn()
 
-	q.Add(&queue.QueueUser{
-		ID:        user.ID,
-		SessionID: sessionID,
-		Conn:      mockConn,
+	q.AddUser(&queue.QueueUser{
+		ID:   user.ID,
+		Conn: mockConn,
 	})
 
 	assert.Equal(t, 1, q.Len())

--- a/internal/handler/websocket_test.go
+++ b/internal/handler/websocket_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyiku/hackz-ptera-back/internal/queue"
-	"github.com/kyiku/hackz-ptera-back/internal/session"
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/queue"
+	"hackz-ptera/back/internal/session"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -1,0 +1,53 @@
+// Package middleware provides HTTP middleware functions.
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+// CORSMiddleware returns a CORS middleware that allows requests from
+// localhost and CloudFront domains.
+func CORSMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			origin := c.Request().Header.Get("Origin")
+
+			// Check if origin is allowed
+			if isAllowedOrigin(origin) {
+				c.Response().Header().Set("Access-Control-Allow-Origin", origin)
+				c.Response().Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+				c.Response().Header().Set("Access-Control-Allow-Headers", "Content-Type")
+				c.Response().Header().Set("Access-Control-Allow-Credentials", "true")
+			}
+
+			// Handle preflight requests
+			if c.Request().Method == http.MethodOptions {
+				return c.NoContent(http.StatusNoContent)
+			}
+
+			return next(c)
+		}
+	}
+}
+
+// isAllowedOrigin checks if the origin is allowed for CORS.
+func isAllowedOrigin(origin string) bool {
+	if origin == "" {
+		return false
+	}
+
+	// Allow localhost for development
+	if strings.HasPrefix(origin, "http://localhost:") {
+		return true
+	}
+
+	// Allow CloudFront domains
+	if strings.HasSuffix(origin, ".cloudfront.net") {
+		return true
+	}
+
+	return false
+}

--- a/internal/middleware/cors_test.go
+++ b/internal/middleware/cors_test.go
@@ -89,7 +89,7 @@ func TestCORSMiddleware_InvalidOrigin(t *testing.T) {
 		return c.String(http.StatusOK, "ok")
 	})
 
-	handler(tc.Context)
+	_ = handler(tc.Context)
 
 	// 不正なオリジンにはCORSヘッダーが設定されない
 	allowOrigin := tc.Recorder.Header().Get("Access-Control-Allow-Origin")

--- a/internal/middleware/cors_test.go
+++ b/internal/middleware/cors_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -1,0 +1,114 @@
+// Package model provides data models for the application.
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Status constants for user state
+const (
+	StatusWaiting       = "waiting"
+	StatusStage1Dino    = "stage1_dino"
+	StatusStage2Captcha = "stage2_captcha"
+	StatusRegistering   = "registering"
+)
+
+// MaxCaptchaAttempts is the maximum number of CAPTCHA attempts allowed.
+const MaxCaptchaAttempts = 3
+
+// MaxOTPAttempts is the maximum number of OTP attempts allowed.
+const MaxOTPAttempts = 3
+
+// User represents a user in the system.
+type User struct {
+	ID        string    // UUID
+	SessionID string    // Session ID (Cookie)
+	JoinedAt  time.Time // When the user joined the queue
+	Status    string    // Current status
+
+	// CAPTCHA fields
+	CaptchaTargetX  int // Target X coordinate for CAPTCHA
+	CaptchaTargetY  int // Target Y coordinate for CAPTCHA
+	CaptchaAttempts int // Number of CAPTCHA attempts (max 3)
+
+	// OTP fields
+	OTPFishName string // Correct fish name for OTP
+	OTPAttempts int    // Number of OTP attempts (max 3)
+
+	// Registration fields
+	RegisterToken    string    // Registration token (UUID)
+	RegisterTokenExp time.Time // Token expiration time (10 minutes)
+}
+
+// NewUser creates a new User with default values.
+func NewUser() *User {
+	return &User{
+		ID:       uuid.New().String(),
+		Status:   StatusWaiting,
+		JoinedAt: time.Now(),
+	}
+}
+
+// validTransitions defines allowed status transitions.
+var validTransitions = map[string][]string{
+	StatusWaiting:       {StatusStage1Dino},
+	StatusStage1Dino:    {StatusStage2Captcha, StatusWaiting},
+	StatusStage2Captcha: {StatusRegistering, StatusWaiting},
+	StatusRegistering:   {StatusWaiting},
+}
+
+// CanTransitionTo checks if the user can transition to the given status.
+func (u *User) CanTransitionTo(status string) bool {
+	allowedStatuses, ok := validTransitions[u.Status]
+	if !ok {
+		return false
+	}
+
+	for _, allowed := range allowedStatuses {
+		if allowed == status {
+			return true
+		}
+	}
+	return false
+}
+
+// ResetToWaiting resets the user's state to waiting.
+// This is called when the user fails at any stage.
+func (u *User) ResetToWaiting() {
+	u.Status = StatusWaiting
+
+	// Reset CAPTCHA state
+	u.CaptchaAttempts = 0
+	u.CaptchaTargetX = 0
+	u.CaptchaTargetY = 0
+
+	// Reset OTP state
+	u.OTPAttempts = 0
+	u.OTPFishName = ""
+
+	// Reset registration token
+	u.RegisterToken = ""
+	u.RegisterTokenExp = time.Time{}
+}
+
+// SetCaptchaTarget sets the CAPTCHA target coordinates.
+func (u *User) SetCaptchaTarget(x, y int) {
+	u.CaptchaTargetX = x
+	u.CaptchaTargetY = y
+}
+
+// IncrementCaptchaAttempts increments the CAPTCHA attempt count.
+// Returns true if the maximum attempts have been exceeded.
+func (u *User) IncrementCaptchaAttempts() bool {
+	u.CaptchaAttempts++
+	return u.CaptchaAttempts >= MaxCaptchaAttempts
+}
+
+// IncrementOTPAttempts increments the OTP attempt count.
+// Returns true if the maximum attempts have been exceeded.
+func (u *User) IncrementOTPAttempts() bool {
+	u.OTPAttempts++
+	return u.OTPAttempts >= MaxOTPAttempts
+}

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -21,6 +21,13 @@ const MaxCaptchaAttempts = 3
 // MaxOTPAttempts is the maximum number of OTP attempts allowed.
 const MaxOTPAttempts = 3
 
+// WebSocketConn defines the interface for WebSocket connections.
+type WebSocketConn interface {
+	WriteMessage(messageType int, data []byte) error
+	WriteJSON(v interface{}) error
+	Close() error
+}
+
 // User represents a user in the system.
 type User struct {
 	ID        string    // UUID
@@ -40,6 +47,9 @@ type User struct {
 	// Registration fields
 	RegisterToken    string    // Registration token (UUID)
 	RegisterTokenExp time.Time // Token expiration time (10 minutes)
+
+	// WebSocket connection
+	Conn WebSocketConn // WebSocket connection for real-time communication
 }
 
 // NewUser creates a new User with default values.

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -97,7 +97,7 @@ func (q *WaitingQueue) BroadcastPositions() {
 	total := len(q.users)
 	for i, user := range q.users {
 		if user.Conn != nil {
-			user.Conn.WriteJSON(map[string]interface{}{
+			_ = user.Conn.WriteJSON(map[string]interface{}{
 				"type":     "queue_update",
 				"position": i + 1,
 				"total":    total,

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1,0 +1,100 @@
+// Package queue provides waiting queue management.
+package queue
+
+import (
+	"sync"
+
+	"hackz-ptera/back/internal/testutil"
+)
+
+// QueueUser represents a user in the waiting queue.
+type QueueUser struct {
+	ID   string
+	Conn *testutil.MockWebSocketConn // WebSocket connection (mock for testing)
+}
+
+// WaitingQueue manages users waiting in line.
+type WaitingQueue struct {
+	users []*QueueUser
+	mu    sync.RWMutex
+}
+
+// NewWaitingQueue creates a new empty waiting queue.
+func NewWaitingQueue() *WaitingQueue {
+	return &WaitingQueue{
+		users: make([]*QueueUser, 0),
+	}
+}
+
+// Add adds a user to the end of the queue.
+func (q *WaitingQueue) Add(user *QueueUser) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.users = append(q.users, user)
+}
+
+// Remove removes a user from the queue by ID.
+func (q *WaitingQueue) Remove(userID string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for i, u := range q.users {
+		if u.ID == userID {
+			q.users = append(q.users[:i], q.users[i+1:]...)
+			return
+		}
+	}
+}
+
+// GetPosition returns the position of a user in the queue (1-indexed).
+// Returns 0 and false if the user is not found.
+func (q *WaitingQueue) GetPosition(userID string) (int, bool) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	for i, u := range q.users {
+		if u.ID == userID {
+			return i + 1, true
+		}
+	}
+	return 0, false
+}
+
+// Len returns the number of users in the queue.
+func (q *WaitingQueue) Len() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return len(q.users)
+}
+
+// PopFront removes and returns the first user in the queue.
+// Returns nil if the queue is empty.
+func (q *WaitingQueue) PopFront() *QueueUser {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if len(q.users) == 0 {
+		return nil
+	}
+
+	user := q.users[0]
+	q.users = q.users[1:]
+	return user
+}
+
+// BroadcastPositions sends position updates to all users in the queue.
+func (q *WaitingQueue) BroadcastPositions() {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	total := len(q.users)
+	for i, user := range q.users {
+		if user.Conn != nil {
+			user.Conn.WriteJSON(map[string]interface{}{
+				"type":     "queue_update",
+				"position": i + 1,
+				"total":    total,
+			})
+		}
+	}
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -4,13 +4,13 @@ package queue
 import (
 	"sync"
 
-	"hackz-ptera/back/internal/testutil"
+	"hackz-ptera/back/internal/model"
 )
 
 // QueueUser represents a user in the waiting queue.
 type QueueUser struct {
 	ID   string
-	Conn *testutil.MockWebSocketConn // WebSocket connection (mock for testing)
+	Conn model.WebSocketConn // WebSocket connection
 }
 
 // WaitingQueue manages users waiting in line.
@@ -26,8 +26,15 @@ func NewWaitingQueue() *WaitingQueue {
 	}
 }
 
-// Add adds a user to the end of the queue.
-func (q *WaitingQueue) Add(user *QueueUser) {
+// Add adds a user to the end of the queue by userID and connection.
+func (q *WaitingQueue) Add(userID string, conn model.WebSocketConn) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.users = append(q.users, &QueueUser{ID: userID, Conn: conn})
+}
+
+// AddUser adds a QueueUser to the end of the queue.
+func (q *WaitingQueue) AddUser(user *QueueUser) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.users = append(q.users, user)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -34,7 +34,7 @@ func TestWaitingQueue_Add(t *testing.T) {
 
 			for i := 0; i < tt.addCount; i++ {
 				mockConn := testutil.NewMockWebSocketConn()
-				q.Add(&QueueUser{
+				q.AddUser(&QueueUser{
 					ID:   string(rune('a' + i)),
 					Conn: mockConn,
 				})
@@ -49,9 +49,9 @@ func TestWaitingQueue_Remove(t *testing.T) {
 	q := NewWaitingQueue()
 
 	mockConn := testutil.NewMockWebSocketConn()
-	q.Add(&QueueUser{ID: "user1", Conn: mockConn})
-	q.Add(&QueueUser{ID: "user2", Conn: testutil.NewMockWebSocketConn()})
-	q.Add(&QueueUser{ID: "user3", Conn: testutil.NewMockWebSocketConn()})
+	q.AddUser(&QueueUser{ID: "user1", Conn: mockConn})
+	q.AddUser(&QueueUser{ID: "user2", Conn: testutil.NewMockWebSocketConn()})
+	q.AddUser(&QueueUser{ID: "user3", Conn: testutil.NewMockWebSocketConn()})
 
 	assert.Equal(t, 3, q.Len())
 
@@ -108,7 +108,7 @@ func TestWaitingQueue_GetPosition(t *testing.T) {
 			q := NewWaitingQueue()
 
 			for i := 0; i < tt.totalUsers; i++ {
-				q.Add(&QueueUser{
+				q.AddUser(&QueueUser{
 					ID:   "user" + string(rune('0'+i)),
 					Conn: testutil.NewMockWebSocketConn(),
 				})
@@ -128,7 +128,7 @@ func TestWaitingQueue_BroadcastPositions(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		mockConns[i] = testutil.NewMockWebSocketConn()
-		q.Add(&QueueUser{
+		q.AddUser(&QueueUser{
 			ID:   "user" + string(rune('0'+i)),
 			Conn: mockConns[i],
 		})
@@ -156,9 +156,9 @@ func TestWaitingQueue_BroadcastPositions(t *testing.T) {
 func TestWaitingQueue_PopFront(t *testing.T) {
 	q := NewWaitingQueue()
 
-	q.Add(&QueueUser{ID: "user1", Conn: testutil.NewMockWebSocketConn()})
-	q.Add(&QueueUser{ID: "user2", Conn: testutil.NewMockWebSocketConn()})
-	q.Add(&QueueUser{ID: "user3", Conn: testutil.NewMockWebSocketConn()})
+	q.AddUser(&QueueUser{ID: "user1", Conn: testutil.NewMockWebSocketConn()})
+	q.AddUser(&QueueUser{ID: "user2", Conn: testutil.NewMockWebSocketConn()})
+	q.AddUser(&QueueUser{ID: "user3", Conn: testutil.NewMockWebSocketConn()})
 
 	// 先頭を取り出し
 	user := q.PopFront()
@@ -189,7 +189,7 @@ func TestWaitingQueue_Concurrent(t *testing.T) {
 			userID := "user" + string(rune('0'+id%10))
 			conn := testutil.NewMockWebSocketConn()
 
-			q.Add(&QueueUser{ID: userID, Conn: conn})
+			q.AddUser(&QueueUser{ID: userID, Conn: conn})
 
 			// 少し待ってから位置を取得
 			time.Sleep(time.Millisecond)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -1,0 +1,50 @@
+// Package response provides helpers for consistent API responses.
+package response
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Success sends a successful JSON response with the given data.
+// The response will always include "error": false.
+func Success(c echo.Context, data map[string]interface{}) error {
+	resp := make(map[string]interface{})
+	resp["error"] = false
+
+	// Merge additional data
+	for k, v := range data {
+		resp[k] = v
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+// Error sends an error JSON response with the given status code and message.
+func Error(c echo.Context, statusCode int, message string) error {
+	return c.JSON(statusCode, map[string]interface{}{
+		"error":   true,
+		"message": message,
+	})
+}
+
+// ErrorWithRedirect sends an error response with a redirect delay.
+// This is used when the client should redirect after a failure.
+func ErrorWithRedirect(c echo.Context, message string, redirectDelay int) error {
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"error":          true,
+		"message":        message,
+		"redirect_delay": redirectDelay,
+	})
+}
+
+// ErrorWithCode sends an error response with a specific error code.
+// This is useful for clients that need to handle specific error types.
+func ErrorWithCode(c echo.Context, statusCode int, code string, message string) error {
+	return c.JSON(statusCode, map[string]interface{}{
+		"error":   true,
+		"code":    code,
+		"message": message,
+	})
+}

--- a/internal/response/response_test.go
+++ b/internal/response/response_test.go
@@ -51,7 +51,7 @@ func TestResponse_Success(t *testing.T) {
 			assert.Equal(t, http.StatusOK, tc.Recorder.Code)
 
 			var resp map[string]interface{}
-			json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+			_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 			assert.Equal(t, false, resp["error"])
 			for _, field := range tt.wantFields {
@@ -109,7 +109,7 @@ func TestResponse_Error(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, tc.Recorder.Code)
 
 			var resp map[string]interface{}
-			json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+			_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 			assert.Equal(t, tt.wantError, resp["error"])
 			assert.Equal(t, tt.message, resp["message"])
@@ -152,7 +152,7 @@ func TestResponse_ErrorWithRedirect(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, tc.Recorder.Code)
 
 			var resp map[string]interface{}
-			json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+			_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 			assert.Equal(t, true, resp["error"])
 			assert.Equal(t, tt.message, resp["message"])
@@ -202,7 +202,7 @@ func TestResponse_ErrorWithCode(t *testing.T) {
 			assert.Equal(t, tt.statusCode, tc.Recorder.Code)
 
 			var resp map[string]interface{}
-			json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
+			_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &resp)
 
 			assert.Equal(t, true, resp["error"])
 			assert.Equal(t, tt.wantCode, resp["code"])
@@ -214,7 +214,7 @@ func TestResponse_ErrorWithCode(t *testing.T) {
 func TestResponse_ContentType(t *testing.T) {
 	tc := testutil.NewTestContext(http.MethodGet, "/", nil)
 
-	Success(tc.Context, map[string]interface{}{"test": true})
+	_ = Success(tc.Context, map[string]interface{}{"test": true})
 
 	contentType := tc.Recorder.Header().Get("Content-Type")
 	assert.Contains(t, contentType, "application/json")

--- a/internal/response/response_test.go
+++ b/internal/response/response_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -1,0 +1,94 @@
+// Package session provides session management functionality.
+package session
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"hackz-ptera/back/internal/model"
+)
+
+// sessionEntry holds a user and its creation time for expiry checking.
+type sessionEntry struct {
+	User      *model.User
+	CreatedAt time.Time
+}
+
+// SessionStore manages user sessions in memory.
+type SessionStore struct {
+	sessions map[string]*sessionEntry
+	mu       sync.RWMutex
+	expiry   time.Duration // 0 means no expiry
+}
+
+// NewSessionStore creates a new SessionStore with no expiry.
+func NewSessionStore() *SessionStore {
+	return &SessionStore{
+		sessions: make(map[string]*sessionEntry),
+		expiry:   0,
+	}
+}
+
+// NewSessionStoreWithExpiry creates a new SessionStore with the specified expiry duration.
+func NewSessionStoreWithExpiry(expiry time.Duration) *SessionStore {
+	return &SessionStore{
+		sessions: make(map[string]*sessionEntry),
+		expiry:   expiry,
+	}
+}
+
+// Create creates a new session and returns the user and session ID.
+func (s *SessionStore) Create() (*model.User, string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	user := model.NewUser()
+	sessionID := uuid.New().String()
+	user.SessionID = sessionID
+
+	s.sessions[sessionID] = &sessionEntry{
+		User:      user,
+		CreatedAt: time.Now(),
+	}
+
+	return user, sessionID
+}
+
+// Get retrieves a user by session ID.
+// Returns nil and false if the session does not exist or has expired.
+func (s *SessionStore) Get(sessionID string) (*model.User, bool) {
+	s.mu.RLock()
+	entry, exists := s.sessions[sessionID]
+	s.mu.RUnlock()
+
+	if !exists {
+		return nil, false
+	}
+
+	// Check expiry if set
+	if s.expiry > 0 && time.Since(entry.CreatedAt) > s.expiry {
+		// Session has expired, delete it
+		s.mu.Lock()
+		delete(s.sessions, sessionID)
+		s.mu.Unlock()
+		return nil, false
+	}
+
+	return entry.User, true
+}
+
+// Delete removes a session by ID.
+func (s *SessionStore) Delete(sessionID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, sessionID)
+}
+
+// Count returns the number of active sessions.
+func (s *SessionStore) Count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.sessions)
+}

--- a/internal/stage/transition.go
+++ b/internal/stage/transition.go
@@ -48,7 +48,7 @@ func (m *TransitionManager) Execute(user *model.User, toStatus string) error {
 			message = "ステージが変更されました"
 		}
 
-		user.Conn.WriteJSON(map[string]interface{}{
+		_ = user.Conn.WriteJSON(map[string]interface{}{
 			"type":    "stage_change",
 			"stage":   toStatus,
 			"message": message,

--- a/internal/stage/transition.go
+++ b/internal/stage/transition.go
@@ -1,0 +1,59 @@
+// Package stage provides stage transition management.
+package stage
+
+import (
+	"errors"
+
+	"hackz-ptera/back/internal/model"
+)
+
+// stageMessages contains the WebSocket messages for each stage.
+var stageMessages = map[string]string{
+	"stage1_dino":    "Dino Run ゲームを開始してください",
+	"stage2_captcha": "CAPTCHAを解いてください",
+	"registering":    "登録フォームに入力してください",
+}
+
+// TransitionManager manages stage transitions.
+type TransitionManager struct{}
+
+// NewTransitionManager creates a new TransitionManager.
+func NewTransitionManager() *TransitionManager {
+	return &TransitionManager{}
+}
+
+// CanTransition checks if the user can transition to the target status.
+// Returns (valid, errorCode).
+func (m *TransitionManager) CanTransition(user *model.User, toStatus string) (bool, string) {
+	if user.CanTransitionTo(toStatus) {
+		return true, ""
+	}
+	return false, "INVALID_TRANSITION"
+}
+
+// Execute performs the stage transition and notifies the user.
+func (m *TransitionManager) Execute(user *model.User, toStatus string) error {
+	valid, errCode := m.CanTransition(user, toStatus)
+	if !valid {
+		return errors.New(errCode)
+	}
+
+	// Update user status
+	user.Status = toStatus
+
+	// Send WebSocket notification
+	if user.Conn != nil {
+		message, ok := stageMessages[toStatus]
+		if !ok {
+			message = "ステージが変更されました"
+		}
+
+		user.Conn.WriteJSON(map[string]interface{}{
+			"type":    "stage_change",
+			"stage":   toStatus,
+			"message": message,
+		})
+	}
+
+	return nil
+}

--- a/internal/stage/transition_test.go
+++ b/internal/stage/transition_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyiku/hackz-ptera-back/internal/model"
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/model"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/stage/transition_test.go
+++ b/internal/stage/transition_test.go
@@ -189,7 +189,7 @@ func TestStageTransition_WebSocketMessage(t *testing.T) {
 			}
 
 			manager := NewTransitionManager()
-			manager.Execute(user, tt.stage)
+			_ = manager.Execute(user, tt.stage)
 
 			err := testutil.WaitFor(100*time.Millisecond, 10*time.Millisecond, func() bool {
 				return mockConn.LastMessage != nil

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -1,0 +1,124 @@
+// Package storage provides S3 storage integration.
+package storage
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"image"
+	"image/png"
+	"math/rand"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// S3ClientInterface defines the interface for S3 operations.
+type S3ClientInterface interface {
+	GetObject(key string) ([]byte, error)
+	PutObject(key string, data []byte) error
+	ListObjects(prefix string) ([]string, error)
+}
+
+// S3Client wraps S3 operations for image storage.
+type S3Client struct {
+	client        S3ClientInterface
+	bucket        string
+	cloudfrontURL string
+}
+
+// NewS3Client creates a new S3Client.
+func NewS3Client(client S3ClientInterface, bucket string, cloudfrontURL string) *S3Client {
+	return &S3Client{
+		client:        client,
+		bucket:        bucket,
+		cloudfrontURL: strings.TrimSuffix(cloudfrontURL, "/"),
+	}
+}
+
+// GetRandomBackgroundImage returns a random background image.
+func (c *S3Client) GetRandomBackgroundImage() (image.Image, error) {
+	keys, err := c.client.ListObjects("backgrounds/")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list background images: %w", err)
+	}
+
+	if len(keys) == 0 {
+		return nil, errors.New("no background images available")
+	}
+
+	// Select random background
+	randomKey := keys[rand.Intn(len(keys))]
+
+	data, err := c.client.GetObject(randomKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get background image: %w", err)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode background image: %w", err)
+	}
+
+	return img, nil
+}
+
+// GetCharacterImage returns the character image.
+func (c *S3Client) GetCharacterImage() (image.Image, error) {
+	data, err := c.client.GetObject("character/char.png")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get character image: %w", err)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode character image: %w", err)
+	}
+
+	return img, nil
+}
+
+// GetFishImageURL returns the CloudFront URL for a fish image.
+func (c *S3Client) GetFishImageURL(fishName string) (string, error) {
+	return fmt.Sprintf("%s/fish/%s.jpg", c.cloudfrontURL, fishName), nil
+}
+
+// UploadCaptchaImage uploads a captcha image and returns its CloudFront URL.
+func (c *S3Client) UploadCaptchaImage(img image.Image) (string, error) {
+	// Generate unique filename
+	filename := uuid.New().String() + ".png"
+	key := "captcha/" + filename
+
+	// Encode image to PNG
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return "", fmt.Errorf("failed to encode captcha image: %w", err)
+	}
+
+	// Upload to S3
+	if err := c.client.PutObject(key, buf.Bytes()); err != nil {
+		return "", fmt.Errorf("failed to upload captcha image: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/%s", c.cloudfrontURL, key)
+	return url, nil
+}
+
+// ListFishImages returns a list of fish names available in storage.
+func (c *S3Client) ListFishImages() ([]string, error) {
+	keys, err := c.client.ListObjects("fish/")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list fish images: %w", err)
+	}
+
+	fishNames := make([]string, 0, len(keys))
+	for _, key := range keys {
+		// Extract fish name from key (e.g., "fish/onikamasu.jpg" -> "onikamasu")
+		name := strings.TrimPrefix(key, "fish/")
+		name = strings.TrimSuffix(name, ".jpg")
+		name = strings.TrimSuffix(name, ".png")
+		fishNames = append(fishNames, name)
+	}
+
+	return fishNames, nil
+}

--- a/internal/storage/s3_test.go
+++ b/internal/storage/s3_test.go
@@ -4,7 +4,7 @@ import (
 	"image"
 	"testing"
 
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -121,7 +121,7 @@ func (m *MockWebSocketConn) GetLastMessageAsMap() map[string]interface{} {
 	}
 
 	var result map[string]interface{}
-	json.Unmarshal(m.LastMessage, &result)
+	_ = json.Unmarshal(m.LastMessage, &result)
 	return result
 }
 
@@ -268,7 +268,7 @@ func (tc *TestContext) SetCookie(name, value string) {
 // GetResponseBody returns the response body as a map.
 func (tc *TestContext) GetResponseBody() map[string]interface{} {
 	var result map[string]interface{}
-	json.Unmarshal(tc.Recorder.Body.Bytes(), &result)
+	_ = json.Unmarshal(tc.Recorder.Body.Bytes(), &result)
 	return result
 }
 
@@ -305,7 +305,7 @@ func WaitForMessage(conn *MockWebSocketConn, timeout time.Duration) map[string]i
 		conn.mu.Lock()
 		if conn.LastMessage != nil {
 			var msg map[string]interface{}
-			json.Unmarshal(conn.LastMessage, &msg)
+			_ = json.Unmarshal(conn.LastMessage, &msg)
 			conn.mu.Unlock()
 			return msg
 		}
@@ -353,7 +353,7 @@ func CreateTestPNG(width, height int) []byte {
 	}
 
 	var buf bytes.Buffer
-	png.Encode(&buf, img)
+	_ = png.Encode(&buf, img)
 	return buf.Bytes()
 }
 
@@ -374,7 +374,7 @@ func CreateTestJPEG(width, height int) []byte {
 	}
 
 	var buf bytes.Buffer
-	jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80})
+	_ = jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80})
 	return buf.Bytes()
 }
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -17,6 +17,21 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// Error code constants for testing
+const (
+	ErrCodeSessionExpired = "SESSION_EXPIRED"
+	ErrCodeInvalidSession = "INVALID_SESSION"
+	ErrCodeTokenExpired   = "TOKEN_EXPIRED"
+	ErrCodeInternalError  = "INTERNAL_ERROR"
+)
+
+// Status constants for testing
+const (
+	StatusWaiting    = "waiting"
+	StatusStage1Dino = "stage1_dino"
+	StatusRegistering = "registering"
+)
+
 // MockWebSocketConn is a mock implementation of WebSocket connection for testing.
 type MockWebSocketConn struct {
 	mu          sync.Mutex
@@ -243,6 +258,23 @@ func NewTestContextWithJSON(method, path string, body interface{}) *TestContext 
 	tc := NewTestContext(method, path, bytes.NewReader(jsonBody))
 	tc.Request.Header.Set("Content-Type", "application/json")
 	return tc
+}
+
+// SetCookie adds a cookie to the test request.
+func (tc *TestContext) SetCookie(name, value string) {
+	tc.Request.AddCookie(&http.Cookie{Name: name, Value: value})
+}
+
+// GetResponseBody returns the response body as a map.
+func (tc *TestContext) GetResponseBody() map[string]interface{} {
+	var result map[string]interface{}
+	json.Unmarshal(tc.Recorder.Body.Bytes(), &result)
+	return result
+}
+
+// GetResponseCode returns the HTTP response status code.
+func (tc *TestContext) GetResponseCode() int {
+	return tc.Recorder.Code
 }
 
 // WaitFor waits for a condition to be true within timeout.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -104,6 +104,13 @@ func (m *MockWebSocketConn) Close() error {
 	return nil
 }
 
+// GetIsClosed returns the closed state of the connection in a thread-safe manner.
+func (m *MockWebSocketConn) GetIsClosed() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.IsClosed
+}
+
 // GetMessages returns all messages sent through this connection.
 func (m *MockWebSocketConn) GetMessages() [][]byte {
 	m.mu.Lock()

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -324,7 +324,7 @@ func WaitForMessages(conn *MockWebSocketConn, n int, timeout time.Duration) []ma
 			result := make([]map[string]interface{}, len(conn.Messages))
 			for i, msg := range conn.Messages {
 				var m map[string]interface{}
-				json.Unmarshal(msg, &m)
+				_ = json.Unmarshal(msg, &m)
 				result[i] = m
 			}
 			conn.mu.Unlock()
@@ -399,6 +399,6 @@ func CreateTestImage(width, height int) image.Image {
 // AssertJSONResponse parses JSON response and returns as map.
 func AssertJSONResponse(rec *httptest.ResponseRecorder) map[string]interface{} {
 	var result map[string]interface{}
-	json.Unmarshal(rec.Body.Bytes(), &result)
+	_ = json.Unmarshal(rec.Body.Bytes(), &result)
 	return result
 }

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -118,7 +118,7 @@ func TestTestContext_SetCookie(t *testing.T) {
 func TestTestContext_GetResponseBody(t *testing.T) {
 	tc := NewTestContext(http.MethodGet, "/test", nil)
 	tc.Recorder.WriteHeader(http.StatusOK)
-	tc.Recorder.Write([]byte(`{"status":"ok"}`))
+	_, _ = tc.Recorder.Write([]byte(`{"status":"ok"}`))
 
 	body := tc.GetResponseBody()
 	assert.Equal(t, "ok", body["status"])

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,191 @@
+package testutil
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockWebSocketConn_WriteMessage(t *testing.T) {
+	conn := NewMockWebSocketConn()
+
+	err := conn.WriteMessage(1, []byte(`{"type":"test"}`))
+	require.NoError(t, err)
+
+	assert.Len(t, conn.Messages, 1)
+	assert.Equal(t, []byte(`{"type":"test"}`), conn.LastMessage)
+}
+
+func TestMockWebSocketConn_WriteJSON(t *testing.T) {
+	conn := NewMockWebSocketConn()
+
+	msg := map[string]string{"type": "test"}
+	err := conn.WriteJSON(msg)
+	require.NoError(t, err)
+
+	assert.Len(t, conn.Messages, 1)
+	result := conn.GetLastMessageAsMap()
+	assert.Equal(t, "test", result["type"])
+}
+
+func TestMockWebSocketConn_Close(t *testing.T) {
+	conn := NewMockWebSocketConn()
+
+	assert.False(t, conn.IsClosed)
+
+	err := conn.Close()
+	require.NoError(t, err)
+	assert.True(t, conn.IsClosed)
+
+	// Closing again should not error
+	err = conn.Close()
+	require.NoError(t, err)
+}
+
+func TestMockS3Client_GetObject(t *testing.T) {
+	client := NewMockS3Client()
+	client.Objects["test-key"] = []byte("test-content")
+
+	data, err := client.GetObject("test-key")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("test-content"), data)
+
+	// Not found
+	_, err = client.GetObject("nonexistent")
+	assert.Error(t, err)
+	assert.IsType(t, &ObjectNotFoundError{}, err)
+}
+
+func TestMockS3Client_PutObject(t *testing.T) {
+	client := NewMockS3Client()
+
+	err := client.PutObject("test-key", []byte("test-content"))
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte("test-content"), client.UploadedData["test-key"])
+}
+
+func TestMockS3Client_ListObjects(t *testing.T) {
+	client := NewMockS3Client()
+	client.Objects["fish/salmon.jpg"] = []byte("data1")
+	client.Objects["fish/tuna.jpg"] = []byte("data2")
+	client.Objects["captcha/bg.png"] = []byte("data3")
+
+	keys, err := client.ListObjects("fish/")
+	require.NoError(t, err)
+	assert.Len(t, keys, 2)
+}
+
+func TestMockBedrockClient_InvokeModel(t *testing.T) {
+	client := NewMockBedrockClient()
+	client.Response = "test response"
+
+	response, err := client.InvokeModel("model-id", "test prompt")
+	require.NoError(t, err)
+	assert.Equal(t, "test response", response)
+	assert.Equal(t, "test prompt", client.LastPrompt)
+	assert.Equal(t, "model-id", client.LastModelID)
+}
+
+func TestTestContext(t *testing.T) {
+	tc := NewTestContext(http.MethodGet, "/test", nil)
+
+	assert.NotNil(t, tc.Echo)
+	assert.NotNil(t, tc.Context)
+	assert.NotNil(t, tc.Request)
+	assert.NotNil(t, tc.Recorder)
+}
+
+func TestTestContextWithJSON(t *testing.T) {
+	body := map[string]string{"key": "value"}
+	tc := NewTestContextWithJSON(http.MethodPost, "/test", body)
+
+	assert.Equal(t, "application/json", tc.Request.Header.Get("Content-Type"))
+}
+
+func TestTestContext_SetCookie(t *testing.T) {
+	tc := NewTestContext(http.MethodGet, "/test", nil)
+	tc.SetCookie("session_id", "test-session")
+
+	cookie, err := tc.Request.Cookie("session_id")
+	require.NoError(t, err)
+	assert.Equal(t, "test-session", cookie.Value)
+}
+
+func TestTestContext_GetResponseBody(t *testing.T) {
+	tc := NewTestContext(http.MethodGet, "/test", nil)
+	tc.Recorder.WriteHeader(http.StatusOK)
+	tc.Recorder.Write([]byte(`{"status":"ok"}`))
+
+	body := tc.GetResponseBody()
+	assert.Equal(t, "ok", body["status"])
+}
+
+func TestTestContext_GetResponseCode(t *testing.T) {
+	tc := NewTestContext(http.MethodGet, "/test", nil)
+	tc.Recorder.WriteHeader(http.StatusCreated)
+
+	assert.Equal(t, http.StatusCreated, tc.GetResponseCode())
+}
+
+func TestWaitFor(t *testing.T) {
+	counter := 0
+
+	err := WaitFor(100*time.Millisecond, 10*time.Millisecond, func() bool {
+		counter++
+		return counter >= 3
+	})
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, counter, 3)
+}
+
+func TestWaitFor_Timeout(t *testing.T) {
+	err := WaitFor(50*time.Millisecond, 10*time.Millisecond, func() bool {
+		return false // Never true
+	})
+
+	assert.Error(t, err)
+	assert.IsType(t, &TimeoutError{}, err)
+}
+
+func TestCreateTestPNG(t *testing.T) {
+	data := CreateTestPNG(100, 100)
+	assert.NotEmpty(t, data)
+	// PNG files start with specific bytes
+	assert.Equal(t, uint8(0x89), data[0])
+	assert.Equal(t, uint8('P'), data[1])
+	assert.Equal(t, uint8('N'), data[2])
+	assert.Equal(t, uint8('G'), data[3])
+}
+
+func TestCreateTestJPEG(t *testing.T) {
+	data := CreateTestJPEG(100, 100)
+	assert.NotEmpty(t, data)
+	// JPEG files start with 0xFFD8
+	assert.Equal(t, uint8(0xFF), data[0])
+	assert.Equal(t, uint8(0xD8), data[1])
+}
+
+func TestCreateTestImage(t *testing.T) {
+	img := CreateTestImage(200, 150)
+	assert.NotNil(t, img)
+	assert.Equal(t, 200, img.Bounds().Dx())
+	assert.Equal(t, 150, img.Bounds().Dy())
+}
+
+func TestConstants(t *testing.T) {
+	// Error code constants
+	assert.Equal(t, "SESSION_EXPIRED", ErrCodeSessionExpired)
+	assert.Equal(t, "INVALID_SESSION", ErrCodeInvalidSession)
+	assert.Equal(t, "TOKEN_EXPIRED", ErrCodeTokenExpired)
+	assert.Equal(t, "INTERNAL_ERROR", ErrCodeInternalError)
+
+	// Status constants
+	assert.Equal(t, "waiting", StatusWaiting)
+	assert.Equal(t, "stage1_dino", StatusStage1Dino)
+	assert.Equal(t, "registering", StatusRegistering)
+}

--- a/internal/token/register_token.go
+++ b/internal/token/register_token.go
@@ -1,0 +1,158 @@
+// Package token provides token management for user registration.
+package token
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"hackz-ptera/back/internal/model"
+)
+
+// TokenExpiry is the duration after which a register token expires.
+const TokenExpiry = 10 * time.Minute
+
+// QueueInterface defines the interface for the waiting queue.
+type QueueInterface interface {
+	Add(userID string, conn *interface{})
+}
+
+// GenerateRegisterToken generates a new register token for the user.
+// Sets the token and expiration time on the user.
+func GenerateRegisterToken(user *model.User) string {
+	token := uuid.New().String()
+	user.RegisterToken = token
+	user.RegisterTokenExp = time.Now().Add(TokenExpiry)
+	return token
+}
+
+// ValidateRegisterToken validates the register token.
+// Returns (valid, errorCode).
+func ValidateRegisterToken(user *model.User, sessionID, token string) (bool, string) {
+	// Check session ID
+	if user.SessionID != sessionID {
+		return false, "INVALID_SESSION"
+	}
+
+	// Check token
+	if token == "" || user.RegisterToken != token {
+		return false, "INVALID_TOKEN"
+	}
+
+	// Check expiration
+	if IsTokenExpired(user) {
+		return false, "TOKEN_EXPIRED"
+	}
+
+	return true, ""
+}
+
+// IsTokenExpired checks if the register token has expired.
+func IsTokenExpired(user *model.User) bool {
+	if user.RegisterTokenExp.IsZero() {
+		return true
+	}
+	return time.Now().After(user.RegisterTokenExp) || time.Now().Equal(user.RegisterTokenExp)
+}
+
+// TokenMonitor monitors register tokens for expiration.
+type TokenMonitor struct {
+	mu            sync.Mutex
+	checkInterval time.Duration
+	queue         WaitingQueueInterface
+	watchers      map[string]chan struct{} // userID -> stop channel
+}
+
+// WaitingQueueInterface defines the queue interface for token monitor.
+type WaitingQueueInterface interface {
+	Add(userID string, conn model.WebSocketConn)
+}
+
+// NewTokenMonitor creates a new token monitor.
+func NewTokenMonitor(checkInterval time.Duration) *TokenMonitor {
+	return &TokenMonitor{
+		checkInterval: checkInterval,
+		watchers:      make(map[string]chan struct{}),
+	}
+}
+
+// SetQueue sets the waiting queue for the monitor.
+func (m *TokenMonitor) SetQueue(queue WaitingQueueInterface) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.queue = queue
+}
+
+// Watch starts monitoring a user's token for expiration.
+func (m *TokenMonitor) Watch(user *model.User) {
+	m.mu.Lock()
+	stopCh := make(chan struct{})
+	m.watchers[user.ID] = stopCh
+	m.mu.Unlock()
+
+	go m.watchUser(user, stopCh)
+}
+
+// watchUser monitors a user's token in the background.
+func (m *TokenMonitor) watchUser(user *model.User, stopCh chan struct{}) {
+	ticker := time.NewTicker(m.checkInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		case <-ticker.C:
+			if IsTokenExpired(user) {
+				m.handleExpiration(user)
+				return
+			}
+		}
+	}
+}
+
+// handleExpiration handles token expiration for a user.
+func (m *TokenMonitor) handleExpiration(user *model.User) {
+	// Send notification via WebSocket
+	if user.Conn != nil {
+		user.Conn.WriteJSON(map[string]interface{}{
+			"code":    "TOKEN_EXPIRED",
+			"message": "登録トークンの有効期限が切れました",
+		})
+		user.Conn.Close()
+	}
+
+	// Reset user to waiting status
+	user.ResetToWaiting()
+
+	// Add back to queue
+	m.mu.Lock()
+	queue := m.queue
+	m.mu.Unlock()
+
+	if queue != nil {
+		queue.Add(user.ID, user.Conn)
+	}
+}
+
+// Unwatch stops monitoring a user's token.
+func (m *TokenMonitor) Unwatch(user *model.User) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if stopCh, ok := m.watchers[user.ID]; ok {
+		close(stopCh)
+		delete(m.watchers, user.ID)
+	}
+}
+
+// Stop stops all monitoring.
+func (m *TokenMonitor) Stop() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, stopCh := range m.watchers {
+		close(stopCh)
+	}
+	m.watchers = make(map[string]chan struct{})
+}

--- a/internal/token/register_token.go
+++ b/internal/token/register_token.go
@@ -115,11 +115,11 @@ func (m *TokenMonitor) watchUser(user *model.User, stopCh chan struct{}) {
 func (m *TokenMonitor) handleExpiration(user *model.User) {
 	// Send notification via WebSocket
 	if user.Conn != nil {
-		user.Conn.WriteJSON(map[string]interface{}{
+		_ = user.Conn.WriteJSON(map[string]interface{}{
 			"code":    "TOKEN_EXPIRED",
 			"message": "登録トークンの有効期限が切れました",
 		})
-		user.Conn.Close()
+		_ = user.Conn.Close()
 	}
 
 	// Reset user to waiting status

--- a/internal/token/register_token_test.go
+++ b/internal/token/register_token_test.go
@@ -184,7 +184,7 @@ func TestRegisterToken_Monitor(t *testing.T) {
 
 			// WaitForで期限切れ処理完了を待機
 			err := testutil.WaitFor(200*time.Millisecond, 10*time.Millisecond, func() bool {
-				return mockConn.IsClosed
+				return mockConn.GetIsClosed()
 			})
 			require.NoError(t, err, "トークン期限切れ処理が完了しなかった")
 
@@ -194,7 +194,7 @@ func TestRegisterToken_Monitor(t *testing.T) {
 			assert.Equal(t, "TOKEN_EXPIRED", msg["code"])
 
 			// 接続が閉じられたことを確認
-			assert.Equal(t, tt.wantConnClosed, mockConn.IsClosed)
+			assert.Equal(t, tt.wantConnClosed, mockConn.GetIsClosed())
 
 			// 待機列に追加されたことを確認
 			if tt.wantQueueReset {
@@ -224,9 +224,9 @@ func TestRegisterToken_MonitorCancel(t *testing.T) {
 
 	// 期限切れ時間が過ぎても接続が閉じられないことを確認
 	err := testutil.WaitFor(200*time.Millisecond, 10*time.Millisecond, func() bool {
-		return mockConn.IsClosed
+		return mockConn.GetIsClosed()
 	})
 	// エラーになることを期待（接続が閉じられていない）
 	assert.Error(t, err, "監視キャンセル後は接続が閉じられないべき")
-	assert.False(t, mockConn.IsClosed)
+	assert.False(t, mockConn.GetIsClosed())
 }

--- a/internal/token/register_token_test.go
+++ b/internal/token/register_token_test.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/kyiku/hackz-ptera-back/internal/model"
-	"github.com/kyiku/hackz-ptera-back/internal/queue"
-	"github.com/kyiku/hackz-ptera-back/internal/testutil"
+	"hackz-ptera/back/internal/model"
+	"hackz-ptera/back/internal/queue"
+	"hackz-ptera/back/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/util/kana.go
+++ b/internal/util/kana.go
@@ -1,0 +1,98 @@
+// Package util provides utility functions.
+package util
+
+import (
+	"strings"
+	"unicode"
+)
+
+// hiraganaStart is the start of the hiragana Unicode block.
+const hiraganaStart = 0x3040
+
+// hiraganaEnd is the end of the hiragana Unicode block.
+const hiraganaEnd = 0x309F
+
+// katakanaStart is the start of the katakana Unicode block.
+const katakanaStart = 0x30A0
+
+// katakanaEnd is the end of the katakana Unicode block.
+const katakanaEnd = 0x30FF
+
+// kanaOffset is the offset between hiragana and katakana.
+const kanaOffset = katakanaStart - hiraganaStart
+
+// HiraganaToKatakana converts all hiragana characters to katakana.
+func HiraganaToKatakana(s string) string {
+	var result strings.Builder
+	for _, r := range s {
+		if r >= hiraganaStart && r <= hiraganaEnd {
+			result.WriteRune(r + kanaOffset)
+		} else {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
+}
+
+// KatakanaToHiragana converts all katakana characters to hiragana.
+func KatakanaToHiragana(s string) string {
+	var result strings.Builder
+	for _, r := range s {
+		if r >= katakanaStart && r <= katakanaEnd {
+			result.WriteRune(r - kanaOffset)
+		} else {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
+}
+
+// NormalizeForComparison normalizes a string for comparison.
+// It converts hiragana to katakana and trims whitespace.
+func NormalizeForComparison(s string) string {
+	// Trim whitespace (including full-width space)
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "\u3000") // Full-width space
+
+	// Convert to katakana
+	return HiraganaToKatakana(s)
+}
+
+// KanaMatch checks if two strings match, ignoring hiragana/katakana differences.
+func KanaMatch(input, answer string) bool {
+	// Handle empty strings
+	if input == "" && answer == "" {
+		return true
+	}
+
+	// Normalize both strings
+	normalizedInput := NormalizeForComparison(input)
+	normalizedAnswer := NormalizeForComparison(answer)
+
+	return normalizedInput == normalizedAnswer
+}
+
+// IsHiragana checks if a rune is a hiragana character.
+func IsHiragana(r rune) bool {
+	return r >= hiraganaStart && r <= hiraganaEnd
+}
+
+// IsKatakana checks if a rune is a katakana character.
+func IsKatakana(r rune) bool {
+	return r >= katakanaStart && r <= katakanaEnd
+}
+
+// IsKana checks if a rune is either hiragana or katakana.
+func IsKana(r rune) bool {
+	return IsHiragana(r) || IsKatakana(r)
+}
+
+// ContainsOnlyKana checks if a string contains only kana characters.
+func ContainsOnlyKana(s string) bool {
+	for _, r := range s {
+		if !IsKana(r) && !unicode.IsSpace(r) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- MockWebSocketConn: WebSocket接続のモック実装
- MockS3Client: S3クライアントのモック実装
- MockBedrockClient: Bedrockクライアントのモック実装
- TestContext: Echo用テストコンテキスト
- 画像生成ヘルパー (CreateTestPNG, CreateTestJPEG, CreateTestImage)
- 非同期テストユーティリティ (WaitFor, WaitForMessage, WaitForMessages)
- エラーコード・ステータス定数の追加

## Test plan
- [x] `go test ./internal/testutil/... -v` が成功すること
- [x] 他のテストからインポートして使用できること

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)