### PR TITLE
feat: implement remaining issues #26, #8, #1

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,48 @@
+// Package config provides configuration management for the application.
+package config
+
+import (
+	"errors"
+	"os"
+	"strconv"
+)
+
+// Config holds the application configuration.
+type Config struct {
+	Port             string
+	AllowedOrigin    string
+	AWSRegion        string
+	S3Bucket         string
+	CloudfrontDomain string
+}
+
+// LoadConfig loads configuration from environment variables.
+func LoadConfig() (*Config, error) {
+	cfg := &Config{
+		Port:             getEnv("PORT", "8080"),
+		AllowedOrigin:    getEnv("ALLOWED_ORIGIN", "http://localhost:5173"),
+		AWSRegion:        getEnv("AWS_REGION", "ap-northeast-1"),
+		S3Bucket:         getEnv("S3_BUCKET", ""),
+		CloudfrontDomain: getEnv("CLOUDFRONT_DOMAIN", ""),
+	}
+
+	return cfg, nil
+}
+
+// Validate validates the configuration.
+func (c *Config) Validate() error {
+	// Validate port is a number
+	if _, err := strconv.Atoi(c.Port); err != nil {
+		return errors.New("invalid port: must be a number")
+	}
+
+	return nil
+}
+
+// getEnv returns the value of an environment variable or a default value.
+func getEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,153 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVars  map[string]string
+		wantPort string
+		wantErr  bool
+	}{
+		{
+			name: "すべての環境変数が設定されている",
+			envVars: map[string]string{
+				"PORT":              "8080",
+				"ALLOWED_ORIGIN":    "http://localhost:5173",
+				"AWS_REGION":        "ap-northeast-1",
+				"S3_BUCKET":         "test-bucket",
+				"CLOUDFRONT_DOMAIN": "https://test.cloudfront.net",
+			},
+			wantPort: "8080",
+			wantErr:  false,
+		},
+		{
+			name:     "デフォルト値が使用される",
+			envVars:  map[string]string{},
+			wantPort: "8080", // デフォルト
+			wantErr:  false,
+		},
+		{
+			name: "PORTのみカスタム",
+			envVars: map[string]string{
+				"PORT": "3000",
+			},
+			wantPort: "3000",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 既存の環境変数を保存
+			savedEnv := make(map[string]string)
+			for _, key := range []string{"PORT", "ALLOWED_ORIGIN", "AWS_REGION", "S3_BUCKET", "CLOUDFRONT_DOMAIN"} {
+				savedEnv[key] = os.Getenv(key)
+				os.Unsetenv(key)
+			}
+
+			// テスト用の環境変数を設定
+			for k, v := range tt.envVars {
+				os.Setenv(k, v)
+			}
+
+			// テスト後に環境変数を復元
+			defer func() {
+				for k, v := range savedEnv {
+					if v != "" {
+						os.Setenv(k, v)
+					} else {
+						os.Unsetenv(k)
+					}
+				}
+			}()
+
+			cfg, err := LoadConfig()
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPort, cfg.Port)
+		})
+	}
+}
+
+func TestConfig_Defaults(t *testing.T) {
+	// 既存の環境変数を保存
+	savedEnv := make(map[string]string)
+	for _, key := range []string{"PORT", "ALLOWED_ORIGIN", "AWS_REGION", "S3_BUCKET", "CLOUDFRONT_DOMAIN"} {
+		savedEnv[key] = os.Getenv(key)
+		os.Unsetenv(key)
+	}
+
+	// テスト後に環境変数を復元
+	defer func() {
+		for k, v := range savedEnv {
+			if v != "" {
+				os.Setenv(k, v)
+			} else {
+				os.Unsetenv(k)
+			}
+		}
+	}()
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+
+	// デフォルト値の確認
+	assert.Equal(t, "8080", cfg.Port)
+	assert.Equal(t, "ap-northeast-1", cfg.AWSRegion)
+	assert.Equal(t, "http://localhost:5173", cfg.AllowedOrigin)
+}
+
+func TestConfig_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+	}{
+		{
+			name: "有効な設定",
+			config: &Config{
+				Port:          "8080",
+				AllowedOrigin: "http://localhost:5173",
+				AWSRegion:     "ap-northeast-1",
+			},
+			wantErr: false,
+		},
+		{
+			name: "不正なポート（文字列）",
+			config: &Config{
+				Port: "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "空のポート",
+			config: &Config{
+				Port: "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/websocket/ping_pong.go
+++ b/internal/websocket/ping_pong.go
@@ -1,0 +1,51 @@
+// Package websocket provides WebSocket message handling utilities.
+package websocket
+
+import (
+	"encoding/json"
+
+	"hackz-ptera/back/internal/model"
+)
+
+// PingHandler handles ping/pong messages for WebSocket connections.
+type PingHandler struct {
+	conn model.WebSocketConn
+}
+
+// NewPingHandler creates a new PingHandler.
+func NewPingHandler(conn model.WebSocketConn) *PingHandler {
+	return &PingHandler{
+		conn: conn,
+	}
+}
+
+// Handle processes a message and returns true if it was a ping message.
+func (h *PingHandler) Handle(message []byte) bool {
+	var msg map[string]interface{}
+	if err := json.Unmarshal(message, &msg); err != nil {
+		return false
+	}
+
+	msgType, ok := msg["type"].(string)
+	if !ok || msgType != "ping" {
+		return false
+	}
+
+	// Send pong response
+	_ = h.conn.WriteJSON(map[string]interface{}{
+		"type": "pong",
+	})
+
+	return true
+}
+
+// IsPingMessage checks if a message is a ping message without processing it.
+func IsPingMessage(message []byte) bool {
+	var msg map[string]interface{}
+	if err := json.Unmarshal(message, &msg); err != nil {
+		return false
+	}
+
+	msgType, ok := msg["type"].(string)
+	return ok && msgType == "ping"
+}

--- a/internal/websocket/ping_pong_test.go
+++ b/internal/websocket/ping_pong_test.go
@@ -1,0 +1,129 @@
+package websocket
+
+import (
+	"encoding/json"
+	"testing"
+
+	"hackz-ptera/back/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPingHandler_HandlePing(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputMsg    map[string]interface{}
+		wantHandled bool
+		wantPong    bool
+	}{
+		{
+			name:        "pingメッセージを処理",
+			inputMsg:    map[string]interface{}{"type": "ping"},
+			wantHandled: true,
+			wantPong:    true,
+		},
+		{
+			name:        "ping以外のメッセージは無視",
+			inputMsg:    map[string]interface{}{"type": "other"},
+			wantHandled: false,
+			wantPong:    false,
+		},
+		{
+			name:        "typeフィールドがないメッセージ",
+			inputMsg:    map[string]interface{}{"data": "test"},
+			wantHandled: false,
+			wantPong:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConn := testutil.NewMockWebSocketConn()
+			handler := NewPingHandler(mockConn)
+
+			msgBytes, _ := json.Marshal(tt.inputMsg)
+			handled := handler.Handle(msgBytes)
+
+			assert.Equal(t, tt.wantHandled, handled)
+
+			if tt.wantPong {
+				pong := mockConn.GetLastMessageAsMap()
+				require.NotNil(t, pong)
+				assert.Equal(t, "pong", pong["type"])
+			}
+		})
+	}
+}
+
+func TestPingHandler_MultiplePings(t *testing.T) {
+	mockConn := testutil.NewMockWebSocketConn()
+	handler := NewPingHandler(mockConn)
+
+	// 複数回のpingを処理
+	for i := 0; i < 10; i++ {
+		pingMsg, _ := json.Marshal(map[string]interface{}{"type": "ping"})
+		handled := handler.Handle(pingMsg)
+		assert.True(t, handled)
+	}
+
+	// すべてのpingに対してpongが送信された
+	assert.Len(t, mockConn.GetMessages(), 10)
+}
+
+func TestPingHandler_ConnectionNotClosed(t *testing.T) {
+	mockConn := testutil.NewMockWebSocketConn()
+	handler := NewPingHandler(mockConn)
+
+	pingMsg, _ := json.Marshal(map[string]interface{}{"type": "ping"})
+	handler.Handle(pingMsg)
+
+	// ping処理で接続が閉じられないことを確認
+	assert.False(t, mockConn.GetIsClosed())
+}
+
+func TestPingHandler_InvalidJSON(t *testing.T) {
+	mockConn := testutil.NewMockWebSocketConn()
+	handler := NewPingHandler(mockConn)
+
+	// 不正なJSONは処理されない
+	handled := handler.Handle([]byte("invalid json"))
+
+	assert.False(t, handled)
+	assert.Empty(t, mockConn.GetMessages())
+}
+
+func TestIsPingMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		message []byte
+		want    bool
+	}{
+		{
+			name:    "pingメッセージ",
+			message: []byte(`{"type": "ping"}`),
+			want:    true,
+		},
+		{
+			name:    "pongメッセージ",
+			message: []byte(`{"type": "pong"}`),
+			want:    false,
+		},
+		{
+			name:    "その他のメッセージ",
+			message: []byte(`{"type": "message", "data": "hello"}`),
+			want:    false,
+		},
+		{
+			name:    "不正なJSON",
+			message: []byte(`invalid`),
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsPingMessage(tt.message)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- #26 Dockerfile作成 - 既に実装済み
- #8 Ping/Pong処理 - WebSocket用のping/pongハンドラーを実装
- #1 プロジェクト基盤セットアップ - 環境変数設定管理を実装

## Changes
- `internal/websocket/ping_pong.go` - Ping/Pongメッセージハンドラー
- `internal/config/config.go` - 設定管理パッケージ
- 両パッケージのテストを追加

## Test plan
- [x] go test ./internal/websocket/... -v
- [x] go test ./internal/config/... -v
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)